### PR TITLE
feature/SC-5828-Add ldapjs reconnect parameter

### DIFF
--- a/src/services/ldap/index.js
+++ b/src/services/ldap/index.js
@@ -109,8 +109,10 @@ module.exports = function LDAPService() {
 				if (!(config && config.url)) {
 					reject(new errors.BadRequest('Invalid URL in config object.'));
 				}
+				//https://github.com/ldapjs/node-ldapjs/issues/318
 				const client = ldap.createClient({
 					url: config.url,
+					reconnect: true,
 				});
 
 				client.bind(username, password, (err) => {


### PR DESCRIPTION
# Description
Adds one parameter to ldap client configuration to enable automatic reconnection to server which reset the after after an unknown amout of idle time. 

This is an attempt to fix problems listed in https://ticketsystem.schul-cloud.org/browse/SC-5280

## Links to Tickets or other pull requests
https://ticketsystem.schul-cloud.org/browse/SC-5728

## Changes
Add one parameter "reconnect: true".

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>

## Deployment
Roll back immediately if it break established behavior and/or causes unexpected behavior/errors. IMHO, can't be tested exhaustively as it targets the interaction with individually configured/different vendor ldap systems at the school sites. 

## New Repos, NPM pakages or vendor scripts

## Approval for review

### Link to Definition of Done
