### PR TITLE
Hotfix 23.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ## Unreleased
 
+## [23.6.1]
+
+### Fixed - 23.6.1
+
+- SC-5733: LDAPSchoolSyncer now uses the Users model service to avoid ignoring indexes due to automatic collation
+
 
 ## [23.6.0] - 2020-07-21
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "schulcloud-server",
-	"version": "23.6.0",
+	"version": "23.6.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "schulcloud-server",
 	"description": "hpi schulcloud server",
-	"version": "23.6.0",
+	"version": "23.6.1",
 	"homepage": "https://schul-cloud.org",
 	"main": "src/",
 	"keywords": [

--- a/src/services/sync/strategies/LDAPSchoolSyncer.js
+++ b/src/services/sync/strategies/LDAPSchoolSyncer.js
@@ -67,7 +67,7 @@ class LDAPSchoolSyncer extends SystemSyncer {
 	}
 
 	createOrUpdateUser(idmUser) {
-		return this.app.service('users').find({
+		return this.app.service('usersModel').find({
 			query: {
 				ldapId: idmUser.ldapUUID,
 			},

--- a/src/services/sync/strategies/LDAPSchoolSyncer.js
+++ b/src/services/sync/strategies/LDAPSchoolSyncer.js
@@ -196,7 +196,7 @@ class LDAPSchoolSyncer extends SystemSyncer {
 		if (Array.isArray(ldapClass.uniqueMembers) === false) {
 			ldapClass.uniqueMembers = [ldapClass.uniqueMembers];
 		}
-		const userData = await this.app.service('users').find(
+		const userData = await this.app.service('usersModel').find(
 			{
 				query:
 				{


### PR DESCRIPTION
Use the users model service to avoid automatic collation in find queries during LDAP sync.

https://ticketsystem.schul-cloud.org/browse/SC-5733