### PR TITLE
Hotfix/2/23.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ## Unreleased
 
-## [23.6.1]
+## [23.6.2] - 2020-07-22
+
+### Fixed - 23.6.2
+
+- SC-5773: LDAPSchoolSyncer now correctly populates classes synced from an LDAP server, even if only students or only teachers are assigned to the class.
+
+
+## [23.6.1] - 2020-07-22
 
 ### Fixed - 23.6.1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "schulcloud-server",
-	"version": "23.6.1",
+	"version": "23.6.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "schulcloud-server",
 	"description": "hpi schulcloud server",
-	"version": "23.6.1",
+	"version": "23.6.2",
 	"homepage": "https://schul-cloud.org",
 	"main": "src/",
 	"keywords": [


### PR DESCRIPTION
https://ticketsystem.schul-cloud.org/browse/SC-5773

Correctly populates classes during LDAP sync.