### PR TITLE
Feature/sc-5754 - is external school attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ## Unreleased
 
+### Added
+
+- SC-5754 Added isExternal attribute to school model. If ldapSchoolIdentifier or source is defined, isExternal will be set to true
+otherwise, if none of them are defined it wil be set to false.
+
 ### Changed
 
 - SC-4289 Changed aggregations in admin tables, classes are now taken only from current year or max grade level, and are sorted

--- a/src/services/school/model.js
+++ b/src/services/school/model.js
@@ -117,6 +117,10 @@ schoolSchema.virtual('documentBaseDir').get(function get() {
 	return getDocumentBaseDir(school);
 });
 
+schoolSchema.virtual('isExternal').get(function get() {
+	return !!this.ldapSchoolIdentifier || !!this.source;
+});
+
 const yearSchema = new Schema({
 	name: {
 		type: String, required: true, match: /^[0-9]{4}\/[0-9]{2}$/, unique: true,

--- a/test/services/school/index.test.js
+++ b/test/services/school/index.test.js
@@ -132,6 +132,16 @@ describe('school service', () => {
 			// here we could test, we have defaultYear added but however we just need any year
 			// to be set and this should not test year logic
 		});
+
+		it('isExternal attribute is true when ldapSchoolIdentifier or source attributes are present', async () => {
+			const serviceCreatedSchool = await schoolService.create(
+				{ ...sampleSchoolData, ldapSchoolIdentifier: 'testId', source: 'testSource' },
+			);
+			if (Object.prototype.hasOwnProperty.call(serviceCreatedSchool, 'ldapSchoolIdentifier' || 'source')) {
+				Object.assign(serviceCreatedSchool, { isExternal: true });
+			}
+			expect(serviceCreatedSchool.isExternal).to.be.true;
+		});
 	});
 
 	describe('patch schools', () => {

--- a/test/services/school/index.test.js
+++ b/test/services/school/index.test.js
@@ -133,14 +133,44 @@ describe('school service', () => {
 			// to be set and this should not test year logic
 		});
 
-		it('isExternal attribute is true when ldapSchoolIdentifier or source attributes are present', async () => {
+		it('isExternal attribute is true when ldapSchoolIdentifier is not undefined', async () => {
 			const serviceCreatedSchool = await schoolService.create(
-				{ ...sampleSchoolData, ldapSchoolIdentifier: 'testId', source: 'testSource' },
+				{ ...sampleSchoolData, ldapSchoolIdentifier: 'testId' },
 			);
-			if (Object.prototype.hasOwnProperty.call(serviceCreatedSchool, 'ldapSchoolIdentifier' || 'source')) {
-				Object.assign(serviceCreatedSchool, { isExternal: true });
-			}
-			expect(serviceCreatedSchool.isExternal).to.be.true;
+			const { _id: schoolId } = serviceCreatedSchool;
+			createdSchoolIds.push(schoolId);
+			const school = await schoolService.get(schoolId);
+			expect(school.isExternal).to.be.true;
+		});
+
+		it('isExternal attribute is true when source is not undefined', async () => {
+			const serviceCreatedSchool = await schoolService.create(
+				{ ...sampleSchoolData, source: 'testSource' },
+			);
+			const { _id: schoolId } = serviceCreatedSchool;
+			createdSchoolIds.push(schoolId);
+			const school = await schoolService.get(schoolId);
+			expect(school.isExternal).to.be.true;
+		});
+
+		it('isExternal attribute is false when ldapSchoolIdentifier is undefined', async () => {
+			const serviceCreatedSchool = await schoolService.create(
+				{ ...sampleSchoolData },
+			);
+			const { _id: schoolId } = serviceCreatedSchool;
+			createdSchoolIds.push(schoolId);
+			const school = await schoolService.get(schoolId);
+			expect(school.isExternal).to.be.false;
+		});
+
+		it('isExternal attribute is false when source is undefined', async () => {
+			const serviceCreatedSchool = await schoolService.create(
+				{ ...sampleSchoolData },
+			);
+			const { _id: schoolId } = serviceCreatedSchool;
+			createdSchoolIds.push(schoolId);
+			const school = await schoolService.get(schoolId);
+			expect(school.isExternal).to.be.false;
 		});
 	});
 

--- a/test/services/school/index.test.js
+++ b/test/services/school/index.test.js
@@ -153,14 +153,14 @@ describe('school service', () => {
 			expect(school.isExternal).to.be.true;
 		});
 
-		it('isExternal attribute is false when ldapSchoolIdentifier is undefined', async () => {
+		it('isExternal attribute is true when ldapSchoolIdentifier and source are defined', async () => {
 			const serviceCreatedSchool = await schoolService.create(
-				{ ...sampleSchoolData },
+				{ ...sampleSchoolData, ldapSchoolIdentifier: 'testId', source: 'testSource' },
 			);
 			const { _id: schoolId } = serviceCreatedSchool;
 			createdSchoolIds.push(schoolId);
 			const school = await schoolService.get(schoolId);
-			expect(school.isExternal).to.be.false;
+			expect(school.isExternal).to.be.true;
 		});
 
 		it('isExternal attribute is false when source is undefined', async () => {


### PR DESCRIPTION
# Description
Adds isExternal attribute to school schema if ldapSchoolIdentifier or source are present.
<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:
  
    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the begining of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
Origin ticket:
https://ticketsystem.schul-cloud.org/browse/SC-5754
Subtask of:
https://ticketsystem.schul-cloud.org/browse/SC-5541

<!--
Base links to copy
- https://github.com/schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.schul-cloud.org/browse/SC-????
-->

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
