### PR TITLE
SC-6533 after finishing first-login process, set forceChangePassword …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,16 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 ## Unreleased
 ## [24.4.2] - 2020-08-31
 
+### Fixed
+
+- SC-6511 - LDAP edit button missing.
+
+## Unreleased
 ## [24.4.1] - 2020-08-31
 
 ### Fixed
 
-- SC-6511 - LDAP edit button missing.
+- SC-6554: CSV-Importer no longer allows patching users with different roles
 
 ## [24.4.0] - 2020-8-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`
 
 ## Unreleased
+## [24.4.1] - 2020-08-31
+
+### Fixed
+
+- SC-6511 - LDAP edit button missing.
 
 ## [24.4.0] - 2020-8-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,14 +18,14 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Fixed
 
-- SC-6511 - LDAP edit button missing.
+- SC-6554: CSV-Importer no longer allows patching users with different roles
 
 ## Unreleased
 ## [24.4.1] - 2020-08-31
 
 ### Fixed
 
-- SC-6554: CSV-Importer no longer allows patching users with different roles
+- SC-6511 - LDAP edit button missing.
 
 ## [24.4.0] - 2020-8-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`
 
 ## Unreleased
-## [24.4.1] - 2020-08-31
+## [24.4.3] - 2020-09-09
+- SC-6533 - Login not possible if admin reset password
+
+## Unreleased
+## [24.4.2] - 2020-08-31
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,12 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 ### Fixed
 - SC-6533 - Login not possible if admin reset password
 
-## Unreleased
 ## [24.4.2] - 2020-08-31
 
 ### Fixed
 
 - SC-6554: CSV-Importer no longer allows patching users with different roles
 
-## Unreleased
 ## [24.4.1] - 2020-08-31
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "schulcloud-server",
-	"version": "24.4.0",
+	"version": "24.4.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "schulcloud-server",
-	"version": "24.4.1",
+	"version": "24.4.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "schulcloud-server",
 	"description": "hpi schulcloud server",
-	"version": "24.4.1",
+	"version": "24.4.3",
 	"homepage": "https://schul-cloud.org",
 	"main": "src/",
 	"keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "schulcloud-server",
 	"description": "hpi schulcloud server",
-	"version": "24.4.0",
+	"version": "24.4.1",
 	"homepage": "https://schul-cloud.org",
 	"main": "src/",
 	"keywords": [

--- a/src/services/school/hooks/index.js
+++ b/src/services/school/hooks/index.js
@@ -242,7 +242,8 @@ exports.after = {
 		// todo: remove id if possible (shouldnt exist)
 		iff(isNotAuthenticated, keep('name', 'purpose', 'systems', '_id', 'id')),
 		iff(populateInQuery,
-			keepInArray('systems', ['_id', 'type', 'alias', 'ldapConfig.active', 'ldapConfig.rootPath'])),
+			keepInArray('systems', ['_id', 'type', 'alias',
+				'ldapConfig.active', 'ldapConfig.provider', 'ldapConfig.rootPath'])),
 		iff(isProvider('external') && !globalHooks.isSuperHero(), discard('storageProvider')),
 	],
 	find: [decorateYears, setStudentsCanCreateTeams],

--- a/src/services/user/firstLogin.js
+++ b/src/services/user/firstLogin.js
@@ -45,7 +45,6 @@ const firstLogin = async (data, params, app) => {
 	const accountUpdate = {};
 	let accountPromise = Promise.resolve();
 	const userUpdate = {};
-	// let userPromise;
 	let consentPromise = Promise.resolve();
 	let updateConsentUsingVersions = Promise.resolve();
 	const user = await app.service('users').get(params.account.userId);
@@ -85,6 +84,7 @@ const firstLogin = async (data, params, app) => {
 	const preferences = user.preferences || {};
 	preferences.firstLogin = true;
 	userUpdate.preferences = preferences;
+	userUpdate.forcePasswordChange = false;
 
 	const userPromise = app.service('users').patch(user._id, userUpdate, { account: params.account });
 


### PR DESCRIPTION
…flag to false

# Description
When a user finishes first-login process, flag forceChangePassword is setted to false in order to prevent client from redirecting to forcePasswordChange page because user has already setted password during first-login process.
<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:
  
    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the begining of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
https://ticketsystem.schul-cloud.org/browse/SC-6533
<!--
Base links to copy
- https://github.com/schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.schul-cloud.org/browse/SC-????
-->

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
