### PR TITLE
SC-6774 Remove no-await-in-loop from eslint exceptions in server

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,6 @@ module.exports = {
 		],
 		'no-tabs': 'off',
 		'no-restricted-syntax': 'off',
-		'no-await-in-loop': 'off',
 		'class-methods-use-this': 'off',
 		'no-underscore-dangle': [
 			'error',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ## [24.4.6] - 2020-09-11
 
-### Changed
+### Changed in 24.4.6
+
 - SC-6733: central personal data does not get updated via CSV import
 
 ## [24.4.5] - 2020-09-10
@@ -39,7 +40,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ## [24.4.4] - 2020-09-08
 
-### Fixed
+### Fixed in 24.4.4]
 
 - SC-6697: updates/sync account username when user is updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Changed - Unreleased
 
+- SC-6774 remove no-await-in-loop from eslint exceptions
 - Extend JWT payload by schoolId and roleIds
 
 ## [24.5.0] - 2020-09-14


### PR DESCRIPTION
As decided by the architecture chapter in https://docs.hpi-schul-cloud.org/display/CARCH/2020-08-26+Architecture+Meeting the selected rule `no-await-in-loop` will be removed from eslint exceptions.