### PR TITLE
SC-6942: fix TSC login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`
 
+## Unreleased
+
+
+## 25.0.3
+
+### Added - 25.0.3
+
+- SC-6942 - add parse method to TSP strategy to declare it can handle the request and to keep authentication params clean
+
+### Fixed - 25.0.3
+
+- SC-6942 - don't override payload defined by authentication method
+- SC-6942 - don't search for account to populate if no username is given in `injectUsername`
+
+
 ## 25.0.2
 
 ### Changed - 25.0.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "schulcloud-server",
-	"version": "25.0.2",
+	"version": "25.0.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "schulcloud-server",
 	"description": "hpi schulcloud server",
-	"version": "25.0.2",
+	"version": "25.0.3",
 	"homepage": "https://schul-cloud.org",
 	"main": "src/",
 	"keywords": [

--- a/src/services/authentication/hooks/index.js
+++ b/src/services/authentication/hooks/index.js
@@ -73,7 +73,7 @@ const injectUserId = async (context) => {
 	const { strategy } = context.data;
 	const systemId = strategy === 'local' ? undefined : context.data.systemId;
 
-	if (strategy !== 'jwt') {
+	if (strategy !== 'jwt' && context.data.username) {
 		return context.app
 			.service('/accounts')
 			.find({

--- a/src/services/authentication/index.js
+++ b/src/services/authentication/index.js
@@ -39,10 +39,18 @@ const authConfig = {
 
 class SCAuthenticationService extends AuthenticationService {
 	async getPayload(authResult, params) {
-		const payload = await super.getPayload(authResult, params);
-		const user = await this.app.service('usersModel').get(authResult.account.userId);
-		payload.schoolId = user.schoolId;
-		payload.roles = user.roles;
+		let payload = await super.getPayload(authResult, params);
+		if (authResult.account && authResult.account.userId) {
+			const user = await this.app.service('usersModel').get(authResult.account.userId);
+			payload = {
+				...payload,
+				accountId: authResult.account._id,
+				systemId: authResult.account.systemId,
+				userId: user._id,
+				schoolId: user.schoolId,
+				roles: user.roles,
+			};
+		}
 		return payload;
 	}
 }

--- a/src/services/authentication/strategies/TSPStrategy.js
+++ b/src/services/authentication/strategies/TSPStrategy.js
@@ -180,11 +180,6 @@ class TSPStrategy extends AuthenticationBaseStrategy {
 		return {
 			authentication: { strategy: this.name },
 			[entity]: account,
-			payload: {
-				accountId: account._id,
-				userId: user._id,
-				systemId: account.systemId,
-			},
 		};
 	}
 }

--- a/src/services/authentication/strategies/TSPStrategy.js
+++ b/src/services/authentication/strategies/TSPStrategy.js
@@ -78,6 +78,15 @@ class TSPStrategy extends AuthenticationBaseStrategy {
 
 	verifyConfiguration() {}
 
+	parse(req, res) {
+		if (req.body && req.body.strategy === 'tsp') {
+			return {
+				strategy: this.name,
+			};
+		}
+		return null;
+	}
+
 	async authenticate(authentication, params) {
 		const { ticket } = authentication;
 		delete authentication.ticket;


### PR DESCRIPTION
Ticket: https://ticketsystem.hpi-schul-cloud.org/browse/SC-6942

- fixes logging in with TSP
- fixes jwt payload being overwritten by random params from malfunctioning hook
- adds the `parse` method to the TSP login strategy to prevent other login strategies to be considered during TSP login