### PR TITLE
Add sc6510 to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 ### Added
 
 - SC-6830 - Added hook to parse request to arrays when > 20 users are requested in adminUsers service
+- SC-6510 - Added Merlin Url Generator for Lern Store
 
 ### Removed
 

--- a/config/default.schema.json
+++ b/config/default.schema.json
@@ -353,6 +353,14 @@
 			"type": "string",
 			"description": "The client id for edu-sharing api access"
 		},
+		"ES_MERLIN_USERNAME": {
+			"type": "string",
+			"description": "The username for Merlin login, used for edusharing"
+		},
+		"ES_MERLIN_PW": {
+			"type": "string",
+			"description": "The password for Merlin login, used for edusharing"
+		},
 		"SILENT_ERROR_ENABLED": {
 			"type": "boolean",
 			"default": false,

--- a/src/services/content/material-model.js
+++ b/src/services/content/material-model.js
@@ -23,6 +23,7 @@ const materialSchema = new Schema({
 	title: { type: String, required: true },
 	client: { type: String, required: true },
 	url: { type: String, required: true },
+	merlinReference: { type: String },
 	license: [{ type: String }],
 	description: { type: String },
 	contentType: { type: Number },

--- a/src/services/edusharing/hooks/merlin.hooks.js
+++ b/src/services/edusharing/hooks/merlin.hooks.js
@@ -1,0 +1,30 @@
+const { authenticate } = require('@feathersjs/authentication');
+const { disallow } = require('feathers-hooks-common');
+const { NotFound } = require('@feathersjs/errors');
+
+const validateReference = (hook) => {
+	if (!hook || !hook.params || !hook.params.query || !hook.params.query.merlinReference) {
+		throw new NotFound(`Missing query params: {merlinReference: fooBar}`);
+	}
+	return hook;
+};
+
+exports.before = {
+	all: [authenticate('jwt')],
+	find: [validateReference],
+	get: [disallow()],
+	create: [disallow()],
+	update: [disallow()],
+	patch: [disallow()],
+	remove: [disallow()],
+};
+
+exports.after = {
+	all: [],
+	find: [],
+	get: [],
+	create: [],
+	update: [],
+	patch: [],
+	remove: [],
+};

--- a/src/services/edusharing/index.js
+++ b/src/services/edusharing/index.js
@@ -19,7 +19,8 @@ class EduSearch {
 
 class MerlinToken {
 	find(data) {
-		return MerlinTokenGenerator.FIND(data);
+		return 'MerlinToken Find';
+		// return MerlinTokenGenerator.FIND(data);
 	}
 }
 

--- a/src/services/edusharing/index.js
+++ b/src/services/edusharing/index.js
@@ -1,8 +1,11 @@
+// eslint-disable-next-line max-classes-per-file
 const { static: staticContent } = require('@feathersjs/express');
 const path = require('path');
 
 const hooks = require('./hooks');
+const merlinHooks = require('./hooks/merlin.hooks');
 const EduSharingConnector = require('./logic/connector');
+const MerlinTokenGenerator = require('./logic/MerlinTokenGenerator');
 
 class EduSearch {
 	find(data) {
@@ -14,7 +17,20 @@ class EduSearch {
 	}
 }
 
+class MerlinToken {
+	find(data) {
+		return MerlinTokenGenerator.FIND(data);
+	}
+}
+
 module.exports = (app) => {
+	const merlinRoute = 'edu-sharing/merlinToken';
+	app.use(merlinRoute, new MerlinToken(), (req, res) => {
+		res.send(res.data);
+	});
+	const merlinService = app.service(merlinRoute);
+	merlinService.hooks(merlinHooks);
+
 	const eduRoute = '/edu-sharing';
 	app.use(eduRoute, new EduSearch(), (req, res) => {
 		res.send(res.data);

--- a/src/services/edusharing/index.js
+++ b/src/services/edusharing/index.js
@@ -19,8 +19,7 @@ class EduSearch {
 
 class MerlinToken {
 	find(data) {
-		return 'MerlinToken Find';
-		// return MerlinTokenGenerator.FIND(data);
+		return MerlinTokenGenerator.FIND(data);
 	}
 }
 

--- a/src/services/edusharing/logic/MerlinTokenGenerator.js
+++ b/src/services/edusharing/logic/MerlinTokenGenerator.js
@@ -1,4 +1,4 @@
-const { Configuration } = require('@schul-cloud/commons');
+/* const { Configuration } = require('@schul-cloud/commons');
 const request = require('request-promise-native');
 
 class MerlinTokenGenerator {
@@ -46,3 +46,4 @@ class MerlinTokenGenerator {
 }
 
 module.exports = MerlinTokenGenerator.Instance;
+ */

--- a/src/services/edusharing/logic/MerlinTokenGenerator.js
+++ b/src/services/edusharing/logic/MerlinTokenGenerator.js
@@ -1,4 +1,4 @@
-const { Configuration } = require('@schul-cloud/commons');
+/* const { Configuration } = require('@schul-cloud/commons');
 const request = require('request-promise-native');
 
 class MerlinTokenGenerator {
@@ -48,4 +48,4 @@ class MerlinTokenGenerator {
 	}
 }
 
-module.exports = MerlinTokenGenerator.Instance;
+module.exports = MerlinTokenGenerator.Instance; */

--- a/src/services/edusharing/logic/MerlinTokenGenerator.js
+++ b/src/services/edusharing/logic/MerlinTokenGenerator.js
@@ -1,14 +1,9 @@
-/* const { Configuration } = require('@schul-cloud/commons');
+const { Configuration } = require('@schul-cloud/commons');
 const request = require('request-promise-native');
 
 class MerlinTokenGenerator {
-	constructor() {
-		if (MerlinTokenGenerator.instance) {
-			return MerlinTokenGenerator.instance;
-		}
-		this.username = Configuration.get('ES_MERLIN_USERNAME');
-		this.password = Configuration.get('ES_MERLIN_PW');
-		MerlinTokenGenerator.instance = this;
+    setup(app) {
+		this.app = app;
 	}
 
 	async FIND(data) {
@@ -25,8 +20,8 @@ class MerlinTokenGenerator {
 				'Content-Type': 'application/x-www-form-urlencoded',
 			},
 			form: {
-				username: this.username,
-				password: this.password,
+				username: Configuration.get('ES_MERLIN_USERNAME'),
+				password: Configuration.get('ES_MERLIN_PW'),
 			},
 		};
 		try {
@@ -36,14 +31,6 @@ class MerlinTokenGenerator {
 			throw Error(`Failed to obtain merlin url. Error: ${e}`);
 		}
 	}
-
-	static get Instance() {
-		if (!MerlinTokenGenerator.instance) {
-			return new MerlinTokenGenerator();
-		}
-		return MerlinTokenGenerator.instance;
-	}
 }
 
-module.exports = MerlinTokenGenerator.Instance;
- */
+module.exports = MerlinTokenGenerator;

--- a/src/services/edusharing/logic/MerlinTokenGenerator.js
+++ b/src/services/edusharing/logic/MerlinTokenGenerator.js
@@ -9,9 +9,6 @@ class MerlinTokenGenerator {
 		this.username = Configuration.get('ES_MERLIN_USERNAME');
 		this.password = Configuration.get('ES_MERLIN_PW');
 		MerlinTokenGenerator.instance = this;
-		if (!this.username || !this.password) {
-			throw Error(`Missing env variables: \n ES_MERLIN_USERNAME:${this.username} \n ES_MERLIN_PW: ${this.password}`);
-		}
 	}
 
 	async FIND(data) {

--- a/src/services/edusharing/logic/MerlinTokenGenerator.js
+++ b/src/services/edusharing/logic/MerlinTokenGenerator.js
@@ -1,4 +1,4 @@
-/* const { Configuration } = require('@schul-cloud/commons');
+const { Configuration } = require('@schul-cloud/commons');
 const request = require('request-promise-native');
 
 class MerlinTokenGenerator {
@@ -48,4 +48,4 @@ class MerlinTokenGenerator {
 	}
 }
 
-module.exports = MerlinTokenGenerator.Instance; */
+module.exports = MerlinTokenGenerator.Instance;

--- a/src/services/edusharing/logic/MerlinTokenGenerator.js
+++ b/src/services/edusharing/logic/MerlinTokenGenerator.js
@@ -1,0 +1,51 @@
+const { Configuration } = require('@schul-cloud/commons');
+const request = require('request-promise-native');
+
+class MerlinTokenGenerator {
+	constructor() {
+		if (MerlinTokenGenerator.instance) {
+			return MerlinTokenGenerator.instance;
+		}
+		this.username = Configuration.get('ES_MERLIN_USERNAME');
+		this.password = Configuration.get('ES_MERLIN_PW');
+		MerlinTokenGenerator.instance = this;
+		if (!this.username || !this.password) {
+			throw Error(`Missing env variables: \n ES_MERLIN_USERNAME:${this.username} \n ES_MERLIN_PW: ${this.password}`);
+		}
+	}
+
+	async FIND(data) {
+		const { merlinReference } = data.query;
+		const url = await this.getMerlinUrl(merlinReference);
+		return url;
+	}
+
+	async getMerlinUrl(ref) {
+		const options = {
+			method: 'POST',
+			url: `http://merlin.nibis.de/auth.php?nbc&identifier=${ref}`,
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			form: {
+				username: this.username,
+				password: this.password,
+			},
+		};
+		try {
+			const merlinUrl = await request(options);
+			return merlinUrl;
+		} catch (e) {
+			throw Error(`Failed to obtain merlin url. Error: ${e}`);
+		}
+	}
+
+	static get Instance() {
+		if (!MerlinTokenGenerator.instance) {
+			return new MerlinTokenGenerator();
+		}
+		return MerlinTokenGenerator.instance;
+	}
+}
+
+module.exports = MerlinTokenGenerator.Instance;

--- a/src/services/edusharing/logic/connector.js
+++ b/src/services/edusharing/logic/connector.js
@@ -16,10 +16,6 @@ const ES_PATH = {
 	TOKEN: '/edu-sharing/oauth2/token',
 };
 
-// file deepcode ignore StaticAccessThis: <Deepcode confuses values and methods>
-// file deepcode ignore PromiseNotCaughtNode: <Catch exists on line 90>
-// file deepcode ignore AttrAccessOnNull: <Accessing attr nodes on line 248>
-
 let lastCookieRenewalTime = null;
 
 class EduSharingConnector {

--- a/src/services/edusharing/logic/connector.js
+++ b/src/services/edusharing/logic/connector.js
@@ -72,7 +72,7 @@ class EduSharingConnector {
 	}
 
 	// gets access_token and refresh_token
-	async getAuth() {
+	getAuth() {
 		const oauthoptions = {
 			method: 'POST',
 			url: `${Configuration.get('ES_DOMAIN')}${ES_PATH.TOKEN}`,
@@ -85,13 +85,13 @@ class EduSharingConnector {
 			)}&password=${Configuration.get('ES_PASSWORD')}`,
 			timeout: REQUEST_TIMEOUT,
 		};
-		try {
-			const result = await request(oauthoptions);
-			const parsedResult = JSON.parse(result);
-			return parsedResult.access_token;
-		} catch (e) {
-			return new GeneralError('Oauth failed', e);
-		}
+		return request(oauthoptions).then((result) => {
+			if (result) {
+				const parsedResult = JSON.parse(result);
+				return Promise.resolve(parsedResult.access_token);
+			}
+			return Promise.reject(new GeneralError('Oauth failed'));
+		});
 	}
 
 	async requestRepeater(options) {

--- a/src/services/lesson/hooks/index.js
+++ b/src/services/lesson/hooks/index.js
@@ -37,6 +37,28 @@ const addShareTokenIfCourseShareable = async (context) => {
 	return lessonModel.findByIdAndUpdate(_id, { shareToken: nanoid(12) }).then(() => context);
 };
 
+// Generate a new url for material that have merlin as source.
+// The url expires after 2 hours
+const convertMerlinUrl = async (context) => {
+	if (
+		context.result &&
+		context.result.materialIds &&
+		context.result.materialIds.some((material) => material.merlinReference)
+	) {
+		const { materialIds } = context.result;
+		await Promise.all(
+			materialIds.map(async (material) => {
+				if (material.merlinReference) {
+					material.url = await context.app
+						.service('edu-sharing/merlinToken')
+						.find({ query: { merlinReference: material.merlinReference } });
+				}
+			})
+		);
+	}
+	return context;
+};
+
 const setPosition = async (context) => {
 	const { courseId, courseGroupId } = context.data;
 	if (courseId || courseGroupId) {
@@ -124,6 +146,7 @@ const populateWhitelist = {
 		'title',
 		'client',
 		'url',
+		'merlinReference',
 		'license',
 		'description',
 		'contentType',
@@ -186,7 +209,7 @@ exports.before = () => ({
 exports.after = {
 	all: [],
 	find: [],
-	get: [],
+	get: [convertMerlinUrl],
 	create: [addShareTokenIfCourseShareable],
 	update: [],
 	patch: [],

--- a/src/services/lesson/hooks/index.js
+++ b/src/services/lesson/hooks/index.js
@@ -146,7 +146,7 @@ const populateWhitelist = {
 		'title',
 		'client',
 		'url',
-		'merlinReference',
+		// 'merlinReference',
 		'license',
 		'description',
 		'contentType',

--- a/src/services/lesson/hooks/index.js
+++ b/src/services/lesson/hooks/index.js
@@ -39,7 +39,7 @@ const addShareTokenIfCourseShareable = async (context) => {
 
 // Generate a new url for material that have merlin as source.
 // The url expires after 2 hours
-const convertMerlinUrl = async (context) => {
+/* const convertMerlinUrl = async (context) => {
 	if (
 		context.result &&
 		context.result.materialIds &&
@@ -57,7 +57,7 @@ const convertMerlinUrl = async (context) => {
 		);
 	}
 	return context;
-};
+}; */
 
 const setPosition = async (context) => {
 	const { courseId, courseGroupId } = context.data;
@@ -209,7 +209,7 @@ exports.before = () => ({
 exports.after = {
 	all: [],
 	find: [],
-	get: [convertMerlinUrl],
+	get: [], // convertMerlinUrl
 	create: [addShareTokenIfCourseShareable],
 	update: [],
 	patch: [],

--- a/src/services/lesson/services/AddMaterialService.js
+++ b/src/services/lesson/services/AddMaterialService.js
@@ -7,9 +7,9 @@ class AddMaterialService {
 	}
 
 	async create(data, params) {
-		const { title, client, url } = data;
+		const { title, client, url, merlinReference } = data;
 
-		const material = await this.app.service('materials').create({ title, client, url });
+		const material = await this.app.service('materials').create({ title, client, url, merlinReference });
 
 		await this.app.service('lessons').patch(params.lesson._id, {
 			courseId: params.lesson.courseId, //

--- a/src/services/lesson/services/AddMaterialService.js
+++ b/src/services/lesson/services/AddMaterialService.js
@@ -7,9 +7,15 @@ class AddMaterialService {
 	}
 
 	async create(data, params) {
-		const { title, client, url, merlinReference } = data;
+		const { title, client, url } = data;
+		let material;
 
-		const material = await this.app.service('materials').create({ title, client, url, merlinReference });
+		if (data.merlinReference) {
+			const { merlinReference } = data;
+			material = await this.app.service('materials').create({ title, client, url, merlinReference });
+		} else {
+			material = await this.app.service('materials').create({ title, client, url });
+		}
 
 		await this.app.service('lessons').patch(params.lesson._id, {
 			courseId: params.lesson.courseId, //

--- a/src/services/lesson/services/AddMaterialService.js
+++ b/src/services/lesson/services/AddMaterialService.js
@@ -8,14 +8,7 @@ class AddMaterialService {
 
 	async create(data, params) {
 		const { title, client, url } = data;
-		let material;
-
-		if (data.merlinReference) {
-			const { merlinReference } = data;
-			material = await this.app.service('materials').create({ title, client, url, merlinReference });
-		} else {
-			material = await this.app.service('materials').create({ title, client, url });
-		}
+		const material = await this.app.service('materials').create({ title, client, url });
 
 		await this.app.service('lessons').patch(params.lesson._id, {
 			courseId: params.lesson.courseId, //


### PR DESCRIPTION
# Description
<!--
Created a service that generates a merlin url upon material request. This gets triggered when the material is searched and the user wants to go to the website of said content OR when the material is stored in a lesson and the lesson gets fetched to the client side.

## Links to Tickets or other pull requests
[SC-6510](https://ticketsystem.hpi-schul-cloud.org/browse/SC-6510)
[Nuxt pr](https://github.com/hpi-schul-cloud/nuxt-client/compare/Feature/sc-6510-make-use-of-merlin-content?expand=1)
<!--
Base links to copy
- https://ticketsystem.schul-cloud.org/browse/SC-6510
-->

## Changes

It changes the url of the material when content/material from Merlin is requested
It is required because Merlin Url expires after 2 hours after request and a new url must be generated

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>
MerlinReference in material model

## Deployment
2 new env variables needs to be set to authorize request to merlin api.
```ES_MERLIN_USERNAME```
```ES_MERLIN_PW```

## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
