### PR TITLE
Do not set keep alive header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ## Unreleased
 
+## [25.0.7] - 2020-10-01
+
+### Removed
+
+- OPS-1316 - removed custom keep-alive header creation in express middleware
+
 ## [25.0.6] - 2020-10-01
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "schulcloud-server",
-	"version": "25.0.6",
+	"version": "25.0.7",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "schulcloud-server",
 	"description": "hpi schulcloud server",
-	"version": "25.0.6",
+	"version": "25.0.7",
 	"homepage": "https://schul-cloud.org",
 	"main": "src/",
 	"keywords": [

--- a/src/app.js
+++ b/src/app.js
@@ -52,14 +52,6 @@ setupSwagger(app);
 initializeRedisClient();
 rabbitMq.setup(app);
 
-// set custom response header for ha proxy
-if (KEEP_ALIVE) {
-	app.use((req, res, next) => {
-		res.setHeader('Connection', 'Keep-Alive');
-		next();
-	});
-}
-
 app
 	.use(compress())
 	.options('*', cors())


### PR DESCRIPTION
Ticket: https://ticketsystem.hpi-schul-cloud.org/browse/OPS-1316

- do not add keep-alive header in express middleware