### PR TITLE
Fix module export of new instance of merlin class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Changed
 
+- SC-6510, fix a minor syntax error when exporting module
 - Update commons to 1.2.7: print configuration on startup, introduce hierarchical configuration file setup
 - SC-6774 remove no-await-in-loop from eslint exceptions
 - Rename statistic mails route, secure it over sync api key now
@@ -67,7 +68,6 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 - SC-6942 - don't override payload defined by authentication method
 - SC-6942 - don't search for account to populate if no username is given in `injectUsername`
-
 
 ## [25.0.2]
 

--- a/src/services/edusharing/logic/MerlinTokenGenerator.js
+++ b/src/services/edusharing/logic/MerlinTokenGenerator.js
@@ -33,4 +33,4 @@ class MerlinTokenGenerator {
 	}
 }
 
-module.exports = MerlinTokenGenerator;
+module.exports = new MerlinTokenGenerator();


### PR DESCRIPTION
This fixes an export issue.

Changed from:
`module.exports = {myClass}` 
to:
`module.exports = {new myClass()}`