### PR TITLE
SC-6080 - move REQUEST_TIMEOUT from globals to Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Changed
 
+- SC-6080 - move REQUEST_TIMEOUT from globals to Configuration
 - SC-6060 - Updated error handling
 
 ### Fixed

--- a/config/default.json
+++ b/config/default.json
@@ -21,5 +21,6 @@
 	"PROMETHEUS": {
 		"METRICS_PATH": "/metrics",
 		"DURATION_BUCKETS_SECONDS": [0.01, 0.05, 0.1, 0.2, 0.5, 0.75, 1, 3, 5, 8, 15, 30, 60, 120]
-	}
+	},
+	"REQUEST_TIMEOUT": 8000
 }

--- a/config/default.schema.json
+++ b/config/default.schema.json
@@ -421,6 +421,12 @@
 				}
 			},
 			"required": ["METRICS_PATH", "DURATION_BUCKETS_SECONDS"]
+		},
+		"REQUEST_TIMEOUT":{
+			"type": "integer",
+			"minimum": 0,
+			"default": 8000,
+			"description": "Default timeout for external requests in milliseconds."
 		}
 	},
 	"required": [

--- a/config/development.json
+++ b/config/development.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "./default.schema.json",
+    "REQUEST_TIMEOUT": 600000
+}

--- a/config/globals.js
+++ b/config/globals.js
@@ -40,7 +40,6 @@ const globals = {
 	DB_PASSWORD: process.env.DB_PASSWORD,
 	DOCUMENT_BASE_DIR: process.env.DOCUMENT_BASE_DIR || 'https://s3.hidrive.strato.com/schul-cloud-hpi/',
 	MAXIMUM_ALLOWABLE_TOTAL_ATTACHMENTS_SIZE_BYTE: 5 * 1024 * 1024, // 5MB
-	REQUEST_TIMEOUT: process.env.REQUEST_TIMEOUT || 8000,
 	MONGOOSE_CONNECTION_POOL_SIZE: parseInt(process.env.MONGOOSE_CONNECTION_POOL_SIZE || '10', 10),
 
 	SC_DOMAIN: process.env.SC_DOMAIN || 'localhost',

--- a/src/helper/externalApiRequest.js
+++ b/src/helper/externalApiRequest.js
@@ -1,10 +1,10 @@
 const request = require('request-promise-native');
-const { REQUEST_TIMEOUT } = require('../../config/globals');
+const { Configuration } = require('@schul-cloud/commons');
 
 const externalApiRequest = (baseUrl) =>
 	request.defaults({
 		baseUrl,
-		timeout: REQUEST_TIMEOUT,
+		timeout: Configuration.get('REQUEST_TIMEOUT'),
 		json: true,
 	});
 

--- a/src/services/calendar/index.js
+++ b/src/services/calendar/index.js
@@ -2,8 +2,8 @@ const request = require('request-promise-native');
 const { static: staticContent } = require('@feathersjs/express');
 const path = require('path');
 
+const { Configuration } = require('@schul-cloud/commons');
 const hooks = require('./hooks');
-const { REQUEST_TIMEOUT } = require('../../../config/globals');
 
 function toQueryString(paramsObject) {
 	return Object.keys(paramsObject)
@@ -186,7 +186,7 @@ class Service {
 			},
 			body: convertEventToJsonApi(data),
 			json: true,
-			timeout: REQUEST_TIMEOUT,
+			timeout: Configuration.get('REQUEST_TIMEOUT'),
 		};
 
 		return request(options).then((events) => {
@@ -212,7 +212,7 @@ class Service {
 				Authorization: userId,
 			},
 			json: true,
-			timeout: REQUEST_TIMEOUT,
+			timeout: Configuration.get('REQUEST_TIMEOUT'),
 		};
 
 		return request(options).then((events) => {
@@ -242,7 +242,7 @@ class Service {
 			},
 			json: true,
 			method: 'DELETE',
-			timeout: REQUEST_TIMEOUT,
+			timeout: Configuration.get('REQUEST_TIMEOUT'),
 			body: { data: [{ type: 'event' }] },
 		};
 
@@ -265,7 +265,7 @@ class Service {
 			},
 			body: convertEventToJsonApi(data),
 			json: true,
-			timeout: REQUEST_TIMEOUT,
+			timeout: Configuration.get('REQUEST_TIMEOUT'),
 		};
 
 		return request(options).then((events) => {

--- a/src/services/content/index.js
+++ b/src/services/content/index.js
@@ -1,15 +1,15 @@
+// eslint-disable-next-line max-classes-per-file
 const request = require('request-promise-native');
 const service = require('feathers-mongoose');
 const { static: staticContent } = require('@feathersjs/express');
 const path = require('path');
+const { Configuration } = require('@schul-cloud/commons');
 const material = require('./material-model');
 
 const resourcesHooks = require('./hooks/resources');
 const redirectHooks = require('./hooks/redirect');
 const searchHooks = require('./hooks/search');
 const materialsHooks = require('./hooks/materials');
-
-const { REQUEST_TIMEOUT } = require('../../../config/globals');
 
 class ResourcesService {
 	constructor(options) {
@@ -22,7 +22,7 @@ class ResourcesService {
 			uri: `${serviceUrls.content}/resources/`,
 			qs: params.query,
 			json: true,
-			timeout: REQUEST_TIMEOUT,
+			timeout: Configuration.get('REQUEST_TIMEOUT'),
 		};
 		return request(options).then((message) => message);
 	}
@@ -32,7 +32,7 @@ class ResourcesService {
 		const options = {
 			uri: `${serviceUrls.content}/resources/${id}`,
 			json: true,
-			timeout: REQUEST_TIMEOUT,
+			timeout: Configuration.get('REQUEST_TIMEOUT'),
 		};
 		return request(options).then((message) => message);
 	}
@@ -53,7 +53,7 @@ class SearchService {
 			uri: `${serviceUrls.content}/search/`,
 			qs: params.query,
 			json: true,
-			timeout: REQUEST_TIMEOUT,
+			timeout: Configuration.get('REQUEST_TIMEOUT'),
 		};
 		return request(options).then((message) => message);
 	}
@@ -73,7 +73,7 @@ class RedirectService {
 		const options = {
 			uri: `${serviceUrls.content}/resources/${id}`,
 			json: true,
-			timeout: REQUEST_TIMEOUT,
+			timeout: Configuration.get('REQUEST_TIMEOUT'),
 		};
 		return request(options).then((resource) => {
 			// Increase Click Counter

--- a/src/services/edusharing/logic/connector.js
+++ b/src/services/edusharing/logic/connector.js
@@ -1,4 +1,3 @@
-const REQUEST_TIMEOUT = 8000; // ms
 const request = require('request-promise-native');
 const { Configuration } = require('@schul-cloud/commons');
 const reqlib = require('app-root-path').require;
@@ -85,7 +84,7 @@ class EduSharingConnector {
 			)}&client_secret=${Configuration.get('ES_OAUTH_SECRET')}&username=${Configuration.get(
 				'ES_USER'
 			)}&password=${Configuration.get('ES_PASSWORD')}`,
-			timeout: REQUEST_TIMEOUT,
+			timeout: Configuration.get('REQUEST_TIMEOUT'),
 		};
 		try {
 			const result = await request(oauthoptions);
@@ -191,7 +190,7 @@ class EduSharingConnector {
 				...EduSharingConnector.headers,
 				cookie: this.authorization,
 			},
-			timeout: REQUEST_TIMEOUT,
+			timeout: Configuration.get('REQUEST_TIMEOUT'),
 		};
 
 		const eduResponse = await this.requestRepeater(options);
@@ -243,7 +242,7 @@ class EduSharingConnector {
 				criterias: [{ property: 'ngsearchword', values: [`${searchQuery.toLowerCase()}`] }],
 				facettes: ['cclom:general_keyword'],
 			}),
-			timeout: REQUEST_TIMEOUT,
+			timeout: Configuration.get('REQUEST_TIMEOUT'),
 		};
 
 		const parsed = await this.requestRepeater(options);

--- a/src/services/helpers/service.js
+++ b/src/services/helpers/service.js
@@ -1,10 +1,11 @@
 const request = require('request-promise-native');
 const reqlib = require('app-root-path').require;
+const { Configuration } = require('@schul-cloud/commons');
 
 const { GeneralError } = reqlib('src/errors');
 const logger = require('../../logger');
 
-const { REQUEST_TIMEOUT, SMTP_SENDER, NODE_ENV, ENVIRONMENTS } = require('../../../config/globals');
+const { SMTP_SENDER, NODE_ENV, ENVIRONMENTS } = require('../../../config/globals');
 
 const checkForToken = (params, app) => {
 	if ((params.headers || {}).token) {
@@ -72,7 +73,7 @@ module.exports = function setup(app) {
 					...Mail,
 				},
 				json: true,
-				timeout: REQUEST_TIMEOUT,
+				timeout: Configuration.get('REQUEST_TIMEOUT'),
 			};
 
 			// send mail with defined transport object in production mode

--- a/src/services/notification/index.js
+++ b/src/services/notification/index.js
@@ -1,10 +1,10 @@
+// eslint-disable-next-line max-classes-per-file
 const request = require('request-promise-native');
 const { static: staticContent } = require('@feathersjs/express');
 const path = require('path');
 
+const { Configuration } = require('@schul-cloud/commons');
 const hooks = require('./hooks/index');
-
-const { REQUEST_TIMEOUT } = require('../../../config/globals');
 
 /**
  * maps jsonapi properties of a response to fit anything but jsonapi
@@ -38,7 +38,7 @@ class MessageService {
 			},
 			body: Object.assign(data, { serviceUrl: serviceUrls.notification }),
 			json: true,
-			timeout: REQUEST_TIMEOUT,
+			timeout: Configuration.get('REQUEST_TIMEOUT'),
 		};
 
 		return request(options).then((response) => response);
@@ -54,7 +54,7 @@ class MessageService {
 				token: userId,
 			},
 			json: true,
-			timeout: REQUEST_TIMEOUT,
+			timeout: Configuration.get('REQUEST_TIMEOUT'),
 		};
 
 		return request(options).then((message) => message);
@@ -80,7 +80,7 @@ class DeviceService {
 				token: userId,
 			},
 			json: true,
-			timeout: REQUEST_TIMEOUT,
+			timeout: Configuration.get('REQUEST_TIMEOUT'),
 		};
 
 		return request(options).then((devices) => devices);
@@ -99,7 +99,7 @@ class DeviceService {
 			},
 			body: data,
 			json: true,
-			timeout: REQUEST_TIMEOUT,
+			timeout: Configuration.get('REQUEST_TIMEOUT'),
 		};
 
 		return request(options).then((response) => mapResponseProps(response));
@@ -113,7 +113,7 @@ class DeviceService {
 			uri: `${serviceUrls.notification}/devices/${id}?token=${userId}`,
 			method: 'DELETE',
 			json: true,
-			timeout: REQUEST_TIMEOUT,
+			timeout: Configuration.get('REQUEST_TIMEOUT'),
 		};
 
 		return request(options).then((message) => message);
@@ -141,7 +141,7 @@ class CallbackService {
 			},
 			body: data,
 			json: true,
-			timeout: REQUEST_TIMEOUT,
+			timeout: Configuration.get('REQUEST_TIMEOUT'),
 		};
 
 		return request(options).then((response) => response);
@@ -167,7 +167,7 @@ class NotificationService {
 				token: userId,
 			},
 			json: true,
-			timeout: REQUEST_TIMEOUT,
+			timeout: Configuration.get('REQUEST_TIMEOUT'),
 		};
 
 		return request(options).then((message) => message);
@@ -184,7 +184,7 @@ class NotificationService {
 				token: userId,
 			},
 			json: true,
-			timeout: REQUEST_TIMEOUT,
+			timeout: Configuration.get('REQUEST_TIMEOUT'),
 		};
 
 		return request(options).then((message) => message);

--- a/src/services/rocketChat/helpers.js
+++ b/src/services/rocketChat/helpers.js
@@ -1,9 +1,5 @@
-const {
-	REQUEST_TIMEOUT,
-	ROCKET_CHAT_URI,
-	ROCKET_CHAT_ADMIN_TOKEN,
-	ROCKET_CHAT_ADMIN_ID,
-} = require('../../../config/globals');
+const { Configuration } = require('@schul-cloud/commons');
+const { ROCKET_CHAT_URI, ROCKET_CHAT_ADMIN_TOKEN, ROCKET_CHAT_ADMIN_ID } = require('../../../config/globals');
 
 /**
  * create a valid options object to call a rocketChat request.
@@ -33,7 +29,7 @@ exports.getRequestOptions = (shortUri, body, asAdmin, auth, method) => {
 		body,
 		headers,
 		json: true,
-		timeout: REQUEST_TIMEOUT,
+		timeout: Configuration.get('REQUEST_TIMEOUT'),
 	};
 };
 


### PR DESCRIPTION
# Description
This PR moves REQUEST_TIMEOUT into Configuration without any renaming.
The development timeout overrides the default which is not touched.
<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:
  
    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the begining of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
- https://ticketsystem.hpi-schul-cloud.org/browse/SC-????
-->

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity <sub><sup>details [on Confluence](https://docs.hpi-schul-cloud.org/x/2S3GBg)</sup></sub>
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
