### PR TITLE
hotfix/4/SC-7476 remove consent triggers hash generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`
 
+## [25.1.7] - 2020-10-26
+
+### Changed
+
+- SC-7476 - Prevent hash generation if user has account
+
 ## [25.1.6] - 2020-10-23
 
 ### Changed
@@ -40,7 +46,6 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 ### Added
 
 ### Removed
-
 
 ## [25.1.1] - 2020-10-12
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "schulcloud-server",
-	"version": "25.1.6",
+	"version": "25.1.7",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5968,7 +5968,7 @@
 			}
 		},
 		"mongoose-diff-history": {
-			"version": "git+https://github.com/schul-cloud/mongoose-diff-history.git#27e292d3931d1d0bb9cf824a001b373c1f007db1",
+			"version": "git+https://github.com/schul-cloud/mongoose-diff-history.git#4df816cd4e8ccc9b0e3c841a9ecb438a4c3a46bd",
 			"from": "git+https://github.com/schul-cloud/mongoose-diff-history.git",
 			"requires": {
 				"deep-empty-object": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "schulcloud-server",
 	"description": "hpi schulcloud server",
-	"version": "25.1.6",
+	"version": "25.1.7",
 	"homepage": "https://schul-cloud.org",
 	"main": "src/",
 	"keywords": [

--- a/src/services/link/index.js
+++ b/src/services/link/index.js
@@ -5,6 +5,7 @@ const service = require('feathers-mongoose');
 const { static: staticContent } = require('@feathersjs/express');
 const path = require('path');
 
+const { BadRequest } = require('@feathersjs/errors');
 const logger = require('../../logger');
 const link = require('./link-model');
 const hooks = require('./hooks');
@@ -72,6 +73,12 @@ module.exports = function setup() {
 			if (data.toHash) {
 				try {
 					const user = ((await app.service('users').find({ query: { email: data.toHash } })) || {}).data[0];
+
+					const account = ((await app.service('accounts').find({ query: { userId: user._id } })) || {})[0];
+					if (account && account.userId) {
+						throw new BadRequest(`User already has an account.`);
+					}
+
 					if (user && user.importHash) linkData.hash = user.importHash;
 					else {
 						await app


### PR DESCRIPTION
# Description
Steps to reproduce on the client:

Go to Students table
Select a student with consent
Open the maintenance screen and remove the student's consent
 

Actual result:

The registration hash/link is generated and 2 buttons (Persönlichen Einladungslink generieren, Einladungslink per E-Mail versenden) should be disabled.


So therefore need to add a validation if the user has account and avoid the hash generation.## Links to Tickets or other pull requests

https://ticketsystem.hpi-schul-cloud.org/browse/SC-7476
## Changes

Add if statement in case of user already has account preventing the hash recreation

## Datasecurity <sub><sup>details [on Confluence](https://docs.hpi-schul-cloud.org/x/2S3GBg)</sup></sub>

## Deployment

## New Repos, NPM pakages or vendor scripts

## Approval for review
- [X] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
