### PR TITLE
Quickfix - split search at dash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 - Fix mocha tests
 - SC-6151 fixed a bug that prevented api docu from being accessible
 - SC-6151 fixed paths to openapi documentation
+- Fixed searching for names including a dash
 
 ## [25.2.0]
 

--- a/migrations/1602693850245-search_index.js
+++ b/migrations/1602693850245-search_index.js
@@ -28,7 +28,7 @@ const User = mongoose.model(
 const splitForSearchIndexes = (...searchTexts) => {
 	const arr = [];
 	searchTexts.forEach((item) => {
-		item.split(' ').forEach((it) => {
+		item.split(/[\s-]/g).forEach((it) => {
 			if (it.length === 0) return;
 
 			arr.push(it.slice(0, 1));

--- a/src/services/user/model/user.schema.js
+++ b/src/services/user/model/user.schema.js
@@ -118,9 +118,9 @@ userSchema.index(
 	},
 	{
 		weights: {
-			firstName: 5,
-			lastName: 5,
-			email: 5,
+			firstName: 10,
+			lastName: 10,
+			email: 10,
 			firstNameSearchValues: 2,
 			lastNameSearchValues: 2,
 			emailSearchValues: 1,

--- a/src/utils/search.js
+++ b/src/utils/search.js
@@ -10,7 +10,7 @@
 const splitForSearchIndexes = (...searchTexts) => {
 	const arr = [];
 	searchTexts.forEach((item) => {
-		item.split(' ').forEach((it) => {
+		item.split(/[\s-]/g).forEach((it) => {
 			// eslint-disable-next-line no-plusplus
 			if (it.length === 0) return;
 

--- a/test/utils/search.test.js
+++ b/test/utils/search.test.js
@@ -10,6 +10,13 @@ describe('tests for search utils', () => {
 			expect(result).to.be.deep.equals(expected);
 		});
 
+		it('slitup at dash', () => {
+			const string = 'Hans-Mustafa';
+			const expected = ['H', 'Ha', 'Han', 'ans', 'M', 'Mu', 'Mus', 'ust', 'sta', 'taf', 'afa'];
+			const result = splitForSearchIndexes(string);
+			expect(result).to.be.deep.equals(expected);
+		});
+
 		it('slitup two value', () => {
 			const string1 = 'Hans P';
 			const string2 = 'e@b.d';


### PR DESCRIPTION
# Description

## Changes
MongoDB use dash to exclude the following word from search. To prevent this it should not be included in the search string. Names with a dash will be handled as two names.


## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
