### PR TITLE
SC-7370 Add optional rootPath attribute to iserv-idm strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 - SC-7411 - add API Specification and validation for /me service
 - SC-7411 - add API Specification and validation for /version service
 - SC-7205 - create new data seed for QA
+- SC-7370 - Add optional rootPath attribute modifier to iserv-idm strategy
 
 ### Changed
 

--- a/src/services/ldap/strategies/iserv-idm.js
+++ b/src/services/ldap/strategies/iserv-idm.js
@@ -15,7 +15,7 @@ class IservIdmLDAPStrategy extends AbstractLDAPStrategy {
 			scope: 'sub',
 			attributes: ['description', 'o', 'dc', 'dn'],
 		};
-		const schools = await this.app.service('ldap').searchCollection(this.config, '', options);
+		const schools = await this.app.service('ldap').searchCollection(this.config, this.config.rootPath || '', options);
 		return schools.map((idmSchool) => ({
 			ldapOu: idmSchool.dn,
 			displayName: idmSchool.description || idmSchool.o,


### PR DESCRIPTION
# Description
Adds an optional rootPath attribute to iserv-idm strategy for local LDAP test container to simulate a Central IServ. See https://github.com/hpi-schul-cloud/ldap-test-tools#creating-an-ldap-configuration.

This will not interfere with production if no explicit rootPath is set.

## Links to Tickets or other pull requests
Follow-up of https://ticketsystem.hpi-schul-cloud.org/browse/SC-7370

## Changes
- iserv-idm strategy will search for schools at the configured rootPath (system.ldapConfig.rootPath) and default to '' (empty string) if no rootPath is configured.

## Datasecurity <sub><sup>details [on Confluence](https://docs.hpi-schul-cloud.org/x/2S3GBg)</sup></sub>
not applicable

## Deployment
Doesn't change deployment. For local configuration, see https://github.com/hpi-schul-cloud/ldap-test-tools#creating-an-ldap-configuration.

## New Repos, NPM pakages or vendor scripts
not applicable

## Approval for review
- [X] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
