### PR TITLE
SC-8390 - prevents Lern-Store collections search when flag is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Fixed
 
+- SC-8390 - Lern-Store collections feature flag was not excluding collections in search
 - SC-8322 prevent wrong assignment from school to storage provider
 
 ### Added

--- a/src/services/edusharing/services/EduSharingConnector.js
+++ b/src/services/edusharing/services/EduSharingConnector.js
@@ -225,7 +225,12 @@ class EduSharingConnector {
 				});
 			}
 
-			if (Configuration.get('FEATURE_ES_COLLECTIONS_ENABLED') && collection) {
+			if (Configuration.get('FEATURE_ES_COLLECTIONS_ENABLED') === false) {
+				criterias.push({
+					property: 'ccm:hpi_lom_general_aggregationlevel',
+					values: ['1'],
+				});
+			} else if (collection) {
 				criterias.push({ property: 'ngsearchword', values: ['*'] });
 				criterias.push({
 					property: 'ccm:hpi_lom_relation',

--- a/test/services/edusharing/services/EduSharingConnector.test.js
+++ b/test/services/edusharing/services/EduSharingConnector.test.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const chai = require('chai');
 const sinon = require('sinon');
 const request = require('request-promise-native');
+const { Configuration } = require('@hpi-schul-cloud/commons');
 const appPromise = require('../../../../src/app');
 const MockNode = JSON.stringify(require('../mock/response-node.json'));
 const MockNodeRestricted = JSON.stringify(require('../mock/response-node-restricted.json'));
@@ -9,7 +10,6 @@ const MockNodes = JSON.stringify(require('../mock/response-nodes.json'));
 const MockAuth = require('../mock/response-auth.json');
 const EduSharingResponse = require('../../../../src/services/edusharing/services/EduSharingResponse');
 const testObjects = require('../../helpers/testObjects')(appPromise);
-const { Configuration } = require('@hpi-schul-cloud/commons');
 
 describe('EduSharing service', () => {
 	let app;
@@ -35,10 +35,10 @@ describe('EduSharing service', () => {
 
 	it('search with an empty query', async () => {
 		try {
-			const student = await testObjects.createTestUser({roles: ['student']});
+			const student = await testObjects.createTestUser({ roles: ['student'] });
 			const paramsStudent = await testObjects.generateRequestParamsFromUser(student);
 
-			paramsStudent.query = {searchQuery: ''};
+			paramsStudent.query = { searchQuery: '' };
 			const response = await eduSharingService.find(paramsStudent);
 
 			chai.expect(JSON.stringify(response)).to.equal(JSON.stringify(eduSharingResponse));
@@ -49,16 +49,16 @@ describe('EduSharing service', () => {
 
 	it('search with params', async () => {
 		try {
-			const student = await testObjects.createTestUser({roles: ['student']});
+			const student = await testObjects.createTestUser({ roles: ['student'] });
 			const paramsStudent = await testObjects.generateRequestParamsFromUser(student);
 
 			sinon.stub(request, 'get').returns(MockAuth);
 
 			const postStub = sinon.stub(request, 'post');
-			postStub.onCall(0).throws({statusCode: 403, message: 'Stubbing request fail'});
+			postStub.onCall(0).throws({ statusCode: 403, message: 'Stubbing request fail' });
 			postStub.onCall(1).returns(MockNodes);
 
-			paramsStudent.query = {searchQuery: 'foo'};
+			paramsStudent.query = { searchQuery: 'foo' };
 			const response = await eduSharingService.find(paramsStudent);
 
 			chai.expect(response.total).to.gte(1);
@@ -72,7 +72,7 @@ describe('EduSharing service', () => {
 
 	it('should search for a collection', async () => {
 		try {
-			const user = await testObjects.createTestUser({roles: ['teacher']});
+			const user = await testObjects.createTestUser({ roles: ['teacher'] });
 			const params = await testObjects.generateRequestParamsFromUser(user);
 
 			// cookie already set
@@ -81,7 +81,7 @@ describe('EduSharing service', () => {
 			const postStub = sinon.stub(request, 'post');
 			postStub.onCall(0).returns(MockNodes);
 
-			params.query = {collection: 'a4808865-da94-4884-bdba-0ad66070e83b'};
+			params.query = { collection: 'a4808865-da94-4884-bdba-0ad66070e83b' };
 			const response = await eduSharingService.find(params);
 
 			chai
@@ -100,14 +100,14 @@ describe('EduSharing service', () => {
 
 	it('should get a node', async () => {
 		try {
-			const user = await testObjects.createTestUser({roles: ['teacher'], schoolId: '5fcfb0bc685b9af4d4abf899'});
+			const user = await testObjects.createTestUser({ roles: ['teacher'], schoolId: '5fcfb0bc685b9af4d4abf899' });
 			const params = await testObjects.generateRequestParamsFromUser(user);
 			const getStub = sinon.stub(request, 'get');
 
 			// cookie already set
 			// getStub.onCall(1).returns(MockAuth);
 			getStub.onCall(0).returns(MockNode);
-			const mockImg = {body: 'dummyImage'};
+			const mockImg = { body: 'dummyImage' };
 			getStub.onCall(1).returns(mockImg);
 
 			const response = await eduSharingService.get('dummyNodeId', params);
@@ -121,7 +121,7 @@ describe('EduSharing service', () => {
 
 	it('should fail to get a restricted node', async () => {
 		try {
-			const user = await testObjects.createTestUser({roles: ['teacher']});
+			const user = await testObjects.createTestUser({ roles: ['teacher'] });
 			const params = await testObjects.generateRequestParamsFromUser(user);
 			const getStub = sinon.stub(request, 'get');
 
@@ -142,7 +142,7 @@ describe('EduSharing service', () => {
 
 	it('should search with searchable flag', async () => {
 		try {
-			const user = await testObjects.createTestUser({roles: ['teacher']});
+			const user = await testObjects.createTestUser({ roles: ['teacher'] });
 			const params = await testObjects.generateRequestParamsFromUser(user);
 
 			// cookie already set
@@ -151,7 +151,7 @@ describe('EduSharing service', () => {
 			const postStub = sinon.stub(request, 'post');
 			postStub.onCall(0).returns(MockNodes);
 
-			params.query = {searchQuery: 'foo'};
+			params.query = { searchQuery: 'foo' };
 			const response = await eduSharingService.find(params);
 
 			chai.expect(postStub.getCalls()[0].args[0].body).contains(`{"property":"ccm:hpi_searchable","values":["1"]}`);
@@ -167,7 +167,6 @@ describe('EduSharing service', () => {
 
 describe('EduSharing config flags', () => {
 	let app;
-	let eduSharingResponse;
 	let eduSharingService;
 	let server;
 	let originalConfiguration;
@@ -176,7 +175,6 @@ describe('EduSharing config flags', () => {
 		originalConfiguration = Configuration.get('FEATURE_ES_COLLECTIONS_ENABLED');
 		app = await appPromise;
 		eduSharingService = app.service('edu-sharing');
-		eduSharingResponse = new EduSharingResponse();
 		server = await app.listen(0);
 	});
 
@@ -192,9 +190,6 @@ describe('EduSharing config flags', () => {
 
 			const user = await testObjects.createTestUser({ roles: ['teacher'] });
 			const params = await testObjects.generateRequestParamsFromUser(user);
-
-			// cookie already set
-			// sinon.stub(request, 'get').returns(MockAuth);
 
 			const postStub = sinon.stub(request, 'post');
 			postStub.onCall(0).returns(MockNodes);


### PR DESCRIPTION
# Description

<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:
  
    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the begining of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
- https://ticketsystem.hpi-schul-cloud.org/browse/SC-8390
- https://github.com/hpi-schul-cloud/nuxt-client/pull/1640
<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
- https://ticketsystem.hpi-schul-cloud.org/browse/SC-????
-->

## Changes

in Lern-Store, the search now does not return collections anymore when the FEATURE_ES_COLLECTIONS_ENABLED=false

<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity <sub><sup>details [on Confluence](https://docs.hpi-schul-cloud.org/x/2S3GBg)</sup></sub>
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
