### PR TITLE
Feature/sc 6950 manage school kreis and official school number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 ### Added
 
 - SC-8029 - Add deletion concept handling for pseudonyms and registration pins
+- SC-6950 - Add access for superhero to change kreisid and officialSchoolNumber
 
 ### Changed
 

--- a/src/services/school/hooks/index.js
+++ b/src/services/school/hooks/index.js
@@ -219,7 +219,8 @@ const validateOfficialSchoolNumber = async (context) => {
 		if (!currentSchool) {
 			throw new Error(`Internal error`);
 		}
-		if (currentSchool.officialSchoolNumber) {
+		const isSuperHero = await globalHooks.hasRole(context, context.params.account.userId, 'superhero');
+		if (!isSuperHero && currentSchool.officialSchoolNumber) {
 			throw new Error(`This school already have an officialSchoolNumber`);
 		}
 		// eg: 'BE-16593' or '16593'
@@ -248,15 +249,19 @@ const validateCounty = async (context) => {
 			throw new Error(`Internal error`);
 		}
 
+		const isSuperHero = await globalHooks.hasRole(context, context.params.account.userId, 'superhero');
+
 		const { county } = context.data;
 		if (
-			!currentSchool.federalState.counties.length ||
-			!currentSchool.federalState.counties.some((c) => c._id.toString() === county.toString())
+			!isSuperHero &&
+			(!currentSchool.federalState.counties.length ||
+				!currentSchool.federalState.counties.some((c) => c._id.toString() === county.toString()))
 		) {
 			throw new Error(`The state doesn't not have a matching county`);
 		}
+
 		/* Tries to replace the existing county with a new one */
-		if (currentSchool.county && JSON.stringify(currentSchool.county) !== JSON.stringify(county)) {
+		if (!isSuperHero && currentSchool.county && JSON.stringify(currentSchool.county) !== JSON.stringify(county)) {
 			throw new Error(`This school already have a county`);
 		}
 		context.data.county = currentSchool.federalState.counties.find((c) => {

--- a/test/services/school/index.test.js
+++ b/test/services/school/index.test.js
@@ -394,6 +394,24 @@ describe('school service', () => {
 			}
 			expect(result.officialSchoolNumber).to.be.equal(schoolNumber);
 		});
+		it('should succeed to update officialSchoolNumber if school already have one and user is a superhero', async () => {
+			const school = await testObjects.createTestSchool({ officialSchoolNumber: 'uw-42069' });
+			const admin = await testObjects.createTestUser({
+				schoolId: school._id,
+				roles: ['superhero'],
+			});
+			const params = await testObjects.generateRequestParamsFromUser(admin);
+
+			const schoolNumber = 'BA-13371';
+			let result;
+
+			try {
+				result = await app.service('/schools').patch(school._id, { officialSchoolNumber: schoolNumber }, params);
+			} catch (err) {
+				throw new Error('should not have failed', err);
+			}
+			expect(result.officialSchoolNumber).to.be.equal(schoolNumber);
+		});
 		it('should fail to update county if state does not have the provided county ', async () => {
 			const school = await testObjects.createTestSchool({ federalState: '0000b186816abba584714c53' });
 			const admin = await testObjects.createTestUser({


### PR DESCRIPTION
https://ticketsystem.hpi-schul-cloud.org/browse/SC-6950

[Server pr](https://github.com/hpi-schul-cloud/schulcloud-server/pull/2187)
[SHD pr](https://github.com/hpi-schul-cloud/superhero-dashboard/pull/105)

This ticket allows super heroes to change 'officialSchoolNumber' and 'county' in the school-document.
See video in [ticket](https://ticketsystem.hpi-schul-cloud.org/browse/SC-6950)