### PR TITLE
SC-8934 - no more autosync for the migrations for the mongodb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ## Unreleased
 
+## [26.0.14] - 2021-04-16
+
+- SC-8934 - no more autosync for the migrations for the mongodb
+
 ## [26.0.13] - 2021-04-15
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "schulcloud-server",
-	"version": "26.0.13",
+	"version": "26.0.14",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "schulcloud-server",
 	"description": "hpi schulcloud server",
-	"version": "26.0.13",
+	"version": "26.0.14",
 	"homepage": "https://hpi-schul-cloud.de/",
 	"main": "src/",
 	"keywords": [

--- a/startup.sh
+++ b/startup.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 # crontab ./crontab && crond
-npm run migration-sync
+# npm run migration-sync
 npm start


### PR DESCRIPTION
# Description
Remove of the Auto Sync of the migrations.
The auto-sync of the migations trigger to much trubel if running massiv pods from Server.

## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/SC-8934

## Changes
Remove of the Auto Sync of the migrations.

## Datasecurity <sub><sup>details [on Confluence](https://docs.hpi-schul-cloud.org/x/2S3GBg)</sup></sub>
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
