### PR TITLE
SC-8898 add missing function for sncy of students and teachers for a class.

### DIFF
--- a/src/logger/syncLogger.js
+++ b/src/logger/syncLogger.js
@@ -11,7 +11,7 @@ const getDevelopFormat = () =>
 const getProductionFormat = () =>
 	format.combine(format.errors({ stack: true }), format.timestamp(), format.prettyPrint({ depth: 5, colorize: false }));
 
-const getTestFormat = () => format.combine(format.prettyPrint({ depth: 5, colorize: true }));
+const getTestFormat = () => format.combine(format.prettyPrint({ depth: 1, colorize: true }));
 
 let selectedFormat;
 switch (NODE_ENV) {

--- a/src/services/sync/repo/class.repo.js
+++ b/src/services/sync/repo/class.repo.js
@@ -18,10 +18,20 @@ const updateClassName = async (classId, className) => {
 	return classModel.findOneAndUpdate({ _id: classId }, { name: className }, { new: true }).lean().exec();
 };
 
+const updateClassStudents = async (classId, students) => {
+	return classModel.findOneAndUpdate({ _id: classId }, { userIds: students }, { new: true }).lean().exec();
+};
+
+const updateClassTeachers = async (classId, teachers) => {
+	return classModel.findOneAndUpdate({ _id: classId }, { teacherIds: teachers }, { new: true }).lean().exec();
+};
+
 const ClassRepo = {
 	findClassByYearAndLdapDn,
 	createClass,
 	updateClassName,
+    updateClassStudents,
+    updateClassTeachers,
 };
 
 module.exports = ClassRepo;

--- a/src/services/sync/repo/class.repo.js
+++ b/src/services/sync/repo/class.repo.js
@@ -36,8 +36,8 @@ const ClassRepo = {
 	findClassByYearAndLdapDn,
 	createClass,
 	updateClassName,
-    updateClassStudents,
-    updateClassTeachers,
+	updateClassStudents,
+	updateClassTeachers,
 };
 
 module.exports = ClassRepo;

--- a/src/services/sync/repo/user.repo.js
+++ b/src/services/sync/repo/user.repo.js
@@ -96,11 +96,23 @@ const findByLdapIdAndSchool = async (ldapId, schoolId) => {
 		.exec();
 };
 
+const findByLdapDnAndSchool = async (ldapDn, schoolId) => {
+	return userModel
+		.find({
+			ldapDn: { $in: ldapDn},
+			schoolId,
+		})
+		.populate('roles')
+		.lean()
+		.exec();
+};
+
 const UserRepo = {
 	private: { createAccount, createUser, updateAccount },
 	createUserAndAccount,
 	updateUserAndAccount,
 	findByLdapIdAndSchool,
+    findByLdapDnAndSchool,
 };
 
 module.exports = UserRepo;

--- a/src/services/sync/repo/user.repo.js
+++ b/src/services/sync/repo/user.repo.js
@@ -104,10 +104,10 @@ const findByLdapIdAndSchool = async (ldapId, schoolId) => {
 		.exec();
 };
 
-const findByLdapDnAndSchool = async (ldapDn, schoolId) => {
+const findByLdapDnsAndSchool = async (ldapDns, schoolId) => {
 	return userModel
 		.find({
-			ldapDn: { $in: ldapDn},
+			ldapDn: { $in: ldapDns },
 			schoolId,
 		})
 		.populate('roles')
@@ -120,7 +120,7 @@ const UserRepo = {
 	createUserAndAccount,
 	updateUserAndAccount,
 	findByLdapIdAndSchool,
-    findByLdapDnAndSchool,
+	findByLdapDnsAndSchool,
 };
 
 module.exports = UserRepo;

--- a/test/services/sync/repo/class.repo.integration.test.js
+++ b/test/services/sync/repo/class.repo.integration.test.js
@@ -34,34 +34,67 @@ describe('class repo', () => {
 		await server.close();
 	});
 
-	it('should successfully create new class', async () => {
-		const className = 'Test Class';
-		const school = await testObjects.createTestSchool();
-		const res = await ClassRepo.createClass({ name: className, schoolId: school._id }, school);
-		expect(res._id).to.be.not.undefined;
-		expect(res.name).to.be.equal(className);
+	describe('createClass', () => {
+		it('should successfully create new class', async () => {
+			const className = 'Test Class';
+			const school = await testObjects.createTestSchool();
+			const res = await ClassRepo.createClass({ name: className, schoolId: school._id }, school);
+			expect(res._id).to.be.not.undefined;
+			expect(res.name).to.be.equal(className);
 
-		createdClasses.push(res);
+			createdClasses.push(res);
+		});
+	});
+	describe('updateClassName', () => {
+		it('should successfully update class name', async () => {
+			const className = 'New Test Class';
+			const clazz = await testObjects.createTestClass({});
+			const res = await ClassRepo.updateClassName(clazz._id, className);
+			expect(res.name).to.be.equal(className);
+		});
 	});
 
-	it('should successfully update class name', async () => {
-		const className = 'New Test Class';
-		const clazz = await testObjects.createTestClass({});
-		const res = await ClassRepo.updateClassName(clazz._id, className);
-		expect(res.name).to.be.equal(className);
+	describe('findClassByYearAndLdapDn', () => {
+		it('should return null if not found', async () => {
+			const res = await ClassRepo.findClassByYearAndLdapDn(undefined, 'Not existed dn');
+			expect(res).to.be.null;
+		});
+
+		it('should find class by ldap and system', async () => {
+			const ldapDN = new ObjectId();
+			const school = await testObjects.createTestSchool();
+			const year = new ObjectId();
+			const clazz = await testObjects.createTestClass({ ldapDN, schoolId: school._id, year });
+			const res = await ClassRepo.findClassByYearAndLdapDn(year, ldapDN);
+			expect(res._id.toString()).to.be.equal(clazz._id.toString());
+		});
 	});
 
-	it('should return null if not found', async () => {
-		const res = await ClassRepo.findClassByYearAndLdapDn(undefined, 'Not existed dn');
-		expect(res).to.be.null;
+	describe('updateClassStudents', () => {
+		it('should update class students', async () => {
+			const existedStudentIds = [new ObjectId(), new ObjectId()];
+			const clazz = await testObjects.createTestClass({ userIds: existedStudentIds });
+			expect(clazz.userIds).eql(existedStudentIds);
+
+			const studentIds = [new ObjectId(), new ObjectId()];
+			await ClassRepo.updateClassStudents(clazz._id, studentIds);
+
+			const foundClass = await classModel.findById(clazz._id);
+			expect(foundClass.userIds).eql(studentIds);
+		});
 	});
 
-	it('should find class by ldap and system', async () => {
-		const ldapDN = new ObjectId();
-		const school = await testObjects.createTestSchool();
-		const year = new ObjectId();
-		const clazz = await testObjects.createTestClass({ ldapDN, schoolId: school._id, year });
-		const res = await ClassRepo.findClassByYearAndLdapDn(year, ldapDN);
-		expect(res._id.toString()).to.be.equal(clazz._id.toString());
+	describe('updateClassTeachers', () => {
+		it('should update class teachers', async () => {
+			const existedTeacherIds = [new ObjectId(), new ObjectId()];
+			const clazz = await testObjects.createTestClass({ teacherIds: existedTeacherIds });
+			expect(clazz.teacherIds).eql(existedTeacherIds);
+
+			const teacherIds = [new ObjectId(), new ObjectId()];
+			await ClassRepo.updateClassTeachers(clazz._id, teacherIds);
+
+			const foundClass = await classModel.findById(clazz._id);
+			expect(foundClass.teacherIds).eql(teacherIds);
+		});
 	});
 });

--- a/test/services/sync/repo/user.repo.integration.test.js
+++ b/test/services/sync/repo/user.repo.integration.test.js
@@ -18,23 +18,13 @@ const { expect } = chai;
 describe('user repo', () => {
 	let app;
 	let server;
-	const createdAccounts = [];
-	const createdUsers = [];
 
 	before(async () => {
 		app = await appPromise;
 		server = await app.listen(0);
 	});
 
-	beforeEach(async () => {});
-
 	afterEach(async () => {
-		const accountPromises = createdAccounts.map((account) => accountModel.remove(account));
-		await Promise.all(accountPromises);
-
-		const userPromises = createdUsers.map((user) => userModel.remove(user));
-		await Promise.all(userPromises);
-
 		await testObjects.cleanup();
 	});
 
@@ -42,122 +32,159 @@ describe('user repo', () => {
 		await server.close();
 	});
 
-	it('should successfully create new user and account', async () => {
-		const school = await testObjects.createTestSchool();
-		const TEST_ROLE = 'blub21';
-		const role = await testObjects.createTestRole({ name: TEST_ROLE, permissions: [] });
-		const email = `max${`${Date.now()}`}@mustermann.de`;
-		const inputUser = {
-			firstName: 'Max',
-			lastName: 'Mustermann',
-			email,
-			schoolId: school._id,
-			ldapDn: 'Test ldap',
-			ldapId: 'Test ldapId',
-			roles: [TEST_ROLE],
-		};
-		const inputAccount = {
-			username: email,
-		};
-		const { user, account } = await UserRepo.createUserAndAccount(inputUser, inputAccount);
-		expect(user._id).to.be.not.undefined;
-		expect(account.userId.toString()).to.be.equal(user._id.toString());
-		expect(account.activated).to.be.true;
-		expect(user.ldapDn).to.be.not.undefined;
-		expect(user.ldapId).to.be.not.undefined;
-		expect(user.roles.length).to.be.equal(1);
-		expect(user.roles[0]._id.toString()).to.be.equal(role._id.toString());
+	describe('createUserAndAccount', () => {
+		const createdAccounts = [];
+		const createdUsers = [];
 
-		createdAccounts.push(account);
-		createdUsers.push(user);
-	});
+		afterEach(async () => {
+			const accountPromises = createdAccounts.map((account) => accountModel.remove(account));
+			await Promise.all(accountPromises);
 
-	it('should throw an error by user creation if email already used', async () => {
-		const school = await testObjects.createTestSchool();
-		const TEST_ROLE = 'blub21';
-		await testObjects.createTestRole({ name: TEST_ROLE, permissions: [] });
+			const userPromises = createdUsers.map((user) => userModel.remove(user));
+			await Promise.all(userPromises);
 
-		const TEST_EMAIL = `test${Date.now()}@example.com`;
-		await testObjects.createTestUser({ email: TEST_EMAIL });
-
-		const inputUser = {
-			firstName: 'Max',
-			lastName: 'Mustermann',
-			email: TEST_EMAIL,
-			schoolId: school._id,
-			ldapDn: 'Test ldap',
-			ldapId: 'Test ldapId',
-			roles: [TEST_ROLE],
-		};
-		const inputAccount = {
-			username: TEST_EMAIL,
-		};
-		expect(UserRepo.createUserAndAccount(inputUser, inputAccount)).to.eventually.throw(BadRequest);
-	});
-
-	it('should successfully update user and account', async () => {
-		const initialFirstName = 'Initial Fname';
-		const initialLastName = 'Initial Lname';
-		const initialEmail = 'initial@email.com';
-		const initialBirthday = new Date();
-		const testUser = await testObjects.createTestUser({
-			firstName: initialFirstName,
-			lastName: initialLastName,
-			birthday: initialBirthday,
-			email: initialEmail,
+			await testObjects.cleanup();
 		});
-		const password = 'password123';
-		const credentials = { username: testUser.email, password };
-		await testObjects.createTestAccount(credentials, 'local', testUser);
 
-		const newFirstName = 'new first name';
-		const newLastName = 'new last name';
-		const newUserName = 'new user name';
-		const { user, account } = await UserRepo.updateUserAndAccount(
-			testUser._id,
-			{ firstName: newFirstName, lastName: newLastName },
-			{ username: newUserName }
-		);
-		expect(user.firstName).to.be.equal(newFirstName);
-		expect(user.lastName).to.be.equal(newLastName);
-		expect(account.username).to.be.equal(newUserName);
-		expect(user.email).to.be.equal(initialEmail);
-		expect(user.birthday.toString()).to.be.equal(initialBirthday.toString());
+		it('should successfully create new user and account', async () => {
+			const school = await testObjects.createTestSchool();
+			const TEST_ROLE = 'blub21';
+			const role = await testObjects.createTestRole({ name: TEST_ROLE, permissions: [] });
+			const email = `max${`${Date.now()}`}@mustermann.de`;
+			const inputUser = {
+				firstName: 'Max',
+				lastName: 'Mustermann',
+				email,
+				schoolId: school._id,
+				ldapDn: 'Test ldap',
+				ldapId: 'Test ldapId',
+				roles: [TEST_ROLE],
+			};
+			const inputAccount = {
+				username: email,
+			};
+			const { user, account } = await UserRepo.createUserAndAccount(inputUser, inputAccount);
+			expect(user._id).to.be.not.undefined;
+			expect(account.userId.toString()).to.be.equal(user._id.toString());
+			expect(account.activated).to.be.true;
+			expect(user.ldapDn).to.be.not.undefined;
+			expect(user.ldapId).to.be.not.undefined;
+			expect(user.roles.length).to.be.equal(1);
+			expect(user.roles[0]._id.toString()).to.be.equal(role._id.toString());
+
+			createdAccounts.push(account);
+			createdUsers.push(user);
+		});
+
+		it('should throw an error by user creation if email already used', async () => {
+			const school = await testObjects.createTestSchool();
+			const TEST_ROLE = 'blub21';
+			await testObjects.createTestRole({ name: TEST_ROLE, permissions: [] });
+
+			const TEST_EMAIL = `test${Date.now()}@example.com`;
+			await testObjects.createTestUser({ email: TEST_EMAIL });
+
+			const inputUser = {
+				firstName: 'Max',
+				lastName: 'Mustermann',
+				email: TEST_EMAIL,
+				schoolId: school._id,
+				ldapDn: 'Test ldap',
+				ldapId: 'Test ldapId',
+				roles: [TEST_ROLE],
+			};
+			const inputAccount = {
+				username: TEST_EMAIL,
+			};
+			expect(UserRepo.createUserAndAccount(inputUser, inputAccount)).to.eventually.throw(BadRequest);
+		});
 	});
+	describe('update user and account', () => {
+		it('should successfully update user and account', async () => {
+			const initialFirstName = 'Initial Fname';
+			const initialLastName = 'Initial Lname';
+			const initialEmail = 'initial@email.com';
+			const initialBirthday = new Date();
+			const testUser = await testObjects.createTestUser({
+				firstName: initialFirstName,
+				lastName: initialLastName,
+				birthday: initialBirthday,
+				email: initialEmail,
+			});
+			const password = 'password123';
+			const credentials = { username: testUser.email, password };
+			await testObjects.createTestAccount(credentials, 'local', testUser);
 
-	it('should throw an error by update if email already used', async () => {
-		const testEmail = `test${Date.now()}@example.com`;
-		const existedEmail = `existed@example.com`;
-
-		await testObjects.createTestUser({ email: existedEmail });
-		const testUser = await testObjects.createTestUser({ email: testEmail });
-		const password = 'password123';
-		const credentials = { username: testUser.email, password };
-		await testObjects.createTestAccount(credentials, 'local', testUser);
-
-		const newFirstName = 'new first name';
-		const newLastName = 'new last name';
-		const newUserName = 'new user name';
-		expect(
-			UserRepo.updateUserAndAccount(
+			const newFirstName = 'new first name';
+			const newLastName = 'new last name';
+			const newUserName = 'new user name';
+			const { user, account } = await UserRepo.updateUserAndAccount(
 				testUser._id,
-				{ firstName: newFirstName, lastName: newLastName, email: existedEmail },
+				{ firstName: newFirstName, lastName: newLastName },
 				{ username: newUserName }
-			)
-		).to.eventually.throw(BadRequest);
+			);
+			expect(user.firstName).to.be.equal(newFirstName);
+			expect(user.lastName).to.be.equal(newLastName);
+			expect(account.username).to.be.equal(newUserName);
+			expect(user.email).to.be.equal(initialEmail);
+			expect(user.birthday.toString()).to.be.equal(initialBirthday.toString());
+		});
+
+		it('should throw an error by update if email already used', async () => {
+			const testEmail = `test${Date.now()}@example.com`;
+			const existedEmail = `existed@example.com`;
+
+			await testObjects.createTestUser({ email: existedEmail });
+			const testUser = await testObjects.createTestUser({ email: testEmail });
+			const password = 'password123';
+			const credentials = { username: testUser.email, password };
+			await testObjects.createTestAccount(credentials, 'local', testUser);
+
+			const newFirstName = 'new first name';
+			const newLastName = 'new last name';
+			const newUserName = 'new user name';
+			expect(
+				UserRepo.updateUserAndAccount(
+					testUser._id,
+					{ firstName: newFirstName, lastName: newLastName, email: existedEmail },
+					{ username: newUserName }
+				)
+			).to.eventually.throw(BadRequest);
+		});
 	});
 
-	it('should return null if not found', async () => {
-		const testSchool = await testObjects.createTestSchool();
-		const res = await UserRepo.findByLdapIdAndSchool('Not existed dn', testSchool._id);
-		expect(res).to.be.null;
+	describe('findByLdapIdAndSchool', () => {
+		it('should return null if not found', async () => {
+			const testSchool = await testObjects.createTestSchool();
+			const res = await UserRepo.findByLdapIdAndSchool('Not existed dn', testSchool._id);
+			expect(res).to.be.null;
+		});
+
+		it('should find user by ldap and school', async () => {
+			const ldapId = new ObjectId();
+			const school = await testObjects.createTestSchool();
+			const testUser = await testObjects.createTestUser({ ldapId, schoolId: school._id });
+			const res = await UserRepo.findByLdapIdAndSchool(ldapId, school._id);
+			expect(res._id.toString()).to.be.equal(testUser._id.toString());
+		});
 	});
 
-	it('should find user by ldap and school', async () => {
-		const ldapId = new ObjectId();
-		const school = await testObjects.createTestSchool();
-		const testUser = await testObjects.createTestUser({ ldapId, schoolId: school._id });
-		const res = await UserRepo.findByLdapIdAndSchool(ldapId, school._id);
-		expect(res._id.toString()).to.be.equal(testUser._id.toString());
+	describe('findByLdapDnsAndSchool', () => {
+		it('should return empty list if not found', async () => {
+			const testSchool = await testObjects.createTestSchool();
+			const res = await UserRepo.findByLdapDnsAndSchool('Not existed dn', testSchool._id);
+			expect(res).to.eql([]);
+		});
+
+		it('should find user by ldap dn and school', async () => {
+			const ldapDns = ['TEST_LDAP_DN', 'TEST_LDAP_DN2'];
+			const school = await testObjects.createTestSchool();
+			const createdUsers = await Promise.all(
+				ldapDns.map((ldapDn) => testObjects.createTestUser({ ldapDn, schoolId: school._id }))
+			);
+			const res = await UserRepo.findByLdapDnsAndSchool(ldapDns, school._id);
+			expect(res[0]._id.toString()).to.be.equal(createdUsers[0]._id.toString());
+			expect(res[1]._id.toString()).to.be.equal(createdUsers[1]._id.toString());
+		});
 	});
 });

--- a/test/services/sync/repo/user.repo.integration.test.js
+++ b/test/services/sync/repo/user.repo.integration.test.js
@@ -96,7 +96,7 @@ describe('user repo', () => {
 			const inputAccount = {
 				username: TEST_EMAIL,
 			};
-			expect(UserRepo.createUserAndAccount(inputUser, inputAccount)).to.eventually.throw(BadRequest);
+			await expect(UserRepo.createUserAndAccount(inputUser, inputAccount)).to.be.rejectedWith(BadRequest);
 		});
 	});
 	describe('update user and account', () => {
@@ -143,13 +143,13 @@ describe('user repo', () => {
 			const newFirstName = 'new first name';
 			const newLastName = 'new last name';
 			const newUserName = 'new user name';
-			expect(
+			await expect(
 				UserRepo.updateUserAndAccount(
 					testUser._id,
 					{ firstName: newFirstName, lastName: newLastName, email: existedEmail },
 					{ username: newUserName }
 				)
-			).to.eventually.throw(BadRequest);
+			).to.be.rejectedWith(BadRequest);
 		});
 	});
 

--- a/test/services/sync/strategies/LDAPSyncerConsumer.integration.test.js
+++ b/test/services/sync/strategies/LDAPSyncerConsumer.integration.test.js
@@ -367,7 +367,7 @@ describe('Ldap Syncer Consumer Integration', () => {
 			const classData = {
 				content: JSON.stringify(contentData),
 			};
-			expect(ldapConsumer.executeMessage(classData)).to.be.rejectedWith(SyncError);
+			await expect(ldapConsumer.executeMessage(classData)).to.be.rejectedWith(SyncError);
 		});
 	});
 });

--- a/test/services/sync/strategies/LDAPSyncerConsumer.integration.test.js
+++ b/test/services/sync/strategies/LDAPSyncerConsumer.integration.test.js
@@ -54,268 +54,320 @@ describe('Ldap Syncer Consumer Integration', () => {
 		await server.close();
 	});
 
-	it('should create school by the data', async () => {
-		const schoolName = 'test school';
-		const system = await testObjects.createTestSystem();
-		const years = await app.service('years').find({ query: { name: '2021/22' } });
-		const currentYear = new SchoolYearFacade(years.data).defaultYear;
-		const states = await app.service('federalStates').find({ query: { abbreviation: 'NI' } });
-		const federalStateId = states.data[0]._id;
-		const contentData = {
-			action: 'syncSchool',
-			syncId: '6082d04c4f92b7557025df7b',
-			data: {
-				school: {
-					name: schoolName,
-					systems: [system._id],
-					ldapSchoolIdentifier: ldapSchoolIDn,
-					currentYear,
-					federalState: federalStateId,
+	describe('school messages', () => {
+		it('should create school by the data', async () => {
+			const schoolName = 'test school';
+			const system = await testObjects.createTestSystem();
+			const years = await app.service('years').find({ query: { name: '2021/22' } });
+			const currentYear = new SchoolYearFacade(years.data).defaultYear;
+			const states = await app.service('federalStates').find({ query: { abbreviation: 'NI' } });
+			const federalStateId = states.data[0]._id;
+			const contentData = {
+				action: 'syncSchool',
+				syncId: '6082d04c4f92b7557025df7b',
+				data: {
+					school: {
+						name: schoolName,
+						systems: [system._id],
+						ldapSchoolIdentifier: ldapSchoolIDn,
+						currentYear,
+						federalState: federalStateId,
+					},
 				},
-			},
-		};
-		const schoolData = {
-			content: JSON.stringify(contentData),
-		};
+			};
+			const schoolData = {
+				content: JSON.stringify(contentData),
+			};
 
-		await ldapConsumer.executeMessage(schoolData);
+			await ldapConsumer.executeMessage(schoolData);
 
-		const foundSchool = await schoolModel.findOne({ ldapSchoolIdentifier: ldapSchoolIDn }).lean().exec();
-		expect(foundSchool).to.be.not.null;
-		expect(foundSchool.name).to.be.equal(schoolName);
-		expect(foundSchool.federalState.toString()).to.be.equal(federalStateId.toString());
-		expect(foundSchool.currentYear.toString()).to.be.equal(currentYear._id.toString());
-	});
-
-	it('should update existing school by the data', async () => {
-		const initialSchoolName = 'Initial School Name';
-		const system = await testObjects.createTestSystem();
-		await testObjects.createTestSchool({
-			name: initialSchoolName,
-			ldapSchoolIdentifier: ldapSchoolIDn,
-			systems: [system._id],
-		});
-		const updatedSchoolName = 'Updated School Name';
-		const contentData = {
-			action: 'syncSchool',
-			syncId: '6082d04c4f92b7557025df7b',
-			data: {
-				school: {
-					name: updatedSchoolName,
-					systems: [system._id],
-					ldapSchoolIdentifier: ldapSchoolIDn,
-				},
-			},
-		};
-		const schoolData = {
-			content: JSON.stringify(contentData),
-		};
-		await ldapConsumer.executeMessage(schoolData);
-
-		const foundSchool = await schoolModel.findOne({ ldapSchoolIdentifier: ldapSchoolIDn }).lean().exec();
-		expect(foundSchool).to.be.not.null;
-		expect(foundSchool.name).to.be.equal(updatedSchoolName);
-	});
-
-	it('should create user by the data', async () => {
-		const testEmail = `test${Date.now()}@example.com`;
-		const firstName = 'test first';
-		const lastName = 'test last';
-		const ldapUserId = 'LDAP_USER_ID';
-
-		const system = await testObjects.createTestSystem();
-		const school = await testObjects.createTestSchool({ ldapSchoolIdentifier: ldapSchoolIDn, systems: [system._id] });
-
-		const contentData = {
-			action: 'syncUser',
-			syncId: '6082d22395baca4f64ef0a1f',
-			data: {
-				user: {
-					firstName,
-					lastName,
-					systemId: system._id.toString(),
-					schoolDn: school.ldapSchoolIdentifier,
-					email: testEmail,
-					ldapDn: ldapUserDn,
-					ldapId: ldapUserId,
-					roles: ['student'],
-				},
-				account: {
-					ldapDn: ldapUserDn,
-					ldapId: ldapUserId,
-					username: accountUserName,
-					systemId: system._id.toString(),
-					schoolDn: school.ldapSchoolIdentifier,
-					activated: true,
-				},
-			},
-		};
-
-		const userData = {
-			content: JSON.stringify(contentData),
-		};
-		await ldapConsumer.executeMessage(userData);
-
-		const foundUser = await userModel.findOne({ ldapDn: ldapUserDn }).lean().exec();
-		expect(foundUser).to.be.not.null;
-		expect(foundUser.email).to.be.equal(testEmail);
-		expect(foundUser.firstName).to.be.equal(firstName);
-		expect(foundUser.lastName).to.be.equal(lastName);
-		expect(foundUser.ldapId).to.be.equal(ldapUserId);
-		expect(foundUser.ldapDn).to.be.equal(ldapUserDn);
-
-		const foundAccount = await accountModel.findOne({ userId: foundUser._id }).lean().exec();
-		expect(foundAccount).to.be.not.null;
-		expect(foundAccount.username).to.be.equal(accountUserName.toLowerCase());
-		expect(foundAccount.systemId.toString()).to.be.equal(system._id.toString());
-		expect(foundAccount.activated).to.be.true;
-	});
-
-	it('should update existing user by the data', async () => {
-		const initialFirstName = 'initial fname';
-		const initialLastName = 'initial lname';
-		const initialEmail = `initial_test${Date.now()}@example.com`;
-		const updatedEmail = `test${Date.now()}@example.com`;
-		const updatedFirstName = 'test first';
-		const updatedLastName = 'test last';
-		const ldapUserId = 'LDAP_USER_ID';
-
-		const system = await testObjects.createTestSystem();
-		const school = await testObjects.createTestSchool({ ldapSchoolIdentifier: ldapSchoolIDn, systems: [system._id] });
-		await testObjects.createTestUser({
-			ldapId: ldapUserId,
-			firstName: initialFirstName,
-			lastName: initialLastName,
-			email: initialEmail,
-			schoolId: school._id,
-		});
-		const contentData = {
-			action: 'syncUser',
-			syncId: '6082d22395baca4f64ef0a1f',
-			data: {
-				user: {
-					firstName: updatedFirstName,
-					lastName: updatedLastName,
-					systemId: system._id.toString(),
-					schoolDn: school.ldapSchoolIdentifier,
-					email: updatedEmail,
-					ldapDn: ldapUserDn,
-					ldapId: ldapUserId,
-					roles: ['student'],
-				},
-				account: {
-					ldapDn: ldapUserDn,
-					ldapId: ldapUserId,
-					username: accountUserName,
-					systemId: system._id.toString(),
-					schoolDn: school.ldapSchoolIdentifier,
-					activated: true,
-				},
-			},
-		};
-
-		const userData = {
-			content: JSON.stringify(contentData),
-		};
-		await ldapConsumer.executeMessage(userData);
-
-		const foundUser = await userModel.findOne({ ldapDn: ldapUserDn }).lean().exec();
-		expect(foundUser).to.be.not.null;
-		expect(foundUser.email).to.be.equal(updatedEmail);
-		expect(foundUser.firstName).to.be.equal(updatedFirstName);
-		expect(foundUser.lastName).to.be.equal(updatedLastName);
-	});
-
-	it('should create class by the data', async () => {
-		const className = 'test class';
-		const system = await testObjects.createTestSystem();
-		const school = await testObjects.createTestSchool({ ldapSchoolIdentifier: ldapSchoolIDn, systems: [system._id] });
-		const contentData = {
-			action: LDAP_SYNC_ACTIONS.SYNC_CLASSES,
-			syncId: '6082c4f2ba4aef3c5c4473fd',
-			data: {
-				class: {
-					name: className,
-					systemId: system._id.toString(),
-					schoolDn: school.ldapSchoolIdentifier,
-					nameFormat: 'static',
-					ldapDN: ldapClassDn,
-					uniqueMembers: ['some uuid'],
-				},
-			},
-			uniqueMembers: [null],
-		};
-		const classData = {
-			content: JSON.stringify(contentData),
-		};
-		await ldapConsumer.executeMessage(classData);
-
-		const foundClass = await classModel.findOne({ ldapDN: ldapClassDn }).lean().exec();
-		expect(foundClass).to.be.not.null;
-		expect(foundClass.name).to.be.equal(className);
-	});
-
-	it('should update existing class by the data', async () => {
-		const initialClassName = 'initial test class';
-
-		const system = await testObjects.createTestSystem();
-		const school = await testObjects.createTestSchool({ ldapSchoolIdentifier: ldapSchoolIDn, systems: [system._id] });
-
-		await testObjects.createTestClass({
-			name: initialClassName,
-			ldapDN: ldapClassDn,
-			schoolId: school._id,
-			year: school.currentYear,
+			const foundSchool = await schoolModel.findOne({ ldapSchoolIdentifier: ldapSchoolIDn }).lean().exec();
+			expect(foundSchool).to.be.not.null;
+			expect(foundSchool.name).to.be.equal(schoolName);
+			expect(foundSchool.federalState.toString()).to.be.equal(federalStateId.toString());
+			expect(foundSchool.currentYear.toString()).to.be.equal(currentYear._id.toString());
 		});
 
-		const updatedClassName = 'updated test class';
-		const contentData = {
-			action: LDAP_SYNC_ACTIONS.SYNC_CLASSES,
-			syncId: '6082c4f2ba4aef3c5c4473fd',
-			data: {
-				class: {
-					name: updatedClassName,
-					systemId: system._id.toString(),
-					schoolDn: school.ldapSchoolIdentifier,
-					nameFormat: 'static',
-					ldapDN: ldapClassDn,
-					uniqueMembers: ['some uuid'],
+		it('should update existing school by the data', async () => {
+			const initialSchoolName = 'Initial School Name';
+			const system = await testObjects.createTestSystem();
+			await testObjects.createTestSchool({
+				name: initialSchoolName,
+				ldapSchoolIdentifier: ldapSchoolIDn,
+				systems: [system._id],
+			});
+			const updatedSchoolName = 'Updated School Name';
+			const contentData = {
+				action: 'syncSchool',
+				syncId: '6082d04c4f92b7557025df7b',
+				data: {
+					school: {
+						name: updatedSchoolName,
+						systems: [system._id],
+						ldapSchoolIdentifier: ldapSchoolIDn,
+					},
 				},
-			},
-			uniqueMembers: [null],
-		};
-		const classData = {
-			content: JSON.stringify(contentData),
-		};
-		await ldapConsumer.executeMessage(classData);
+			};
+			const schoolData = {
+				content: JSON.stringify(contentData),
+			};
+			await ldapConsumer.executeMessage(schoolData);
 
-		const foundClass = await classModel.findOne({ ldapDN: ldapClassDn }).lean().exec();
-		expect(foundClass).to.be.not.null;
-		expect(foundClass.name).to.be.equal(updatedClassName);
+			const foundSchool = await schoolModel.findOne({ ldapSchoolIdentifier: ldapSchoolIDn }).lean().exec();
+			expect(foundSchool).to.be.not.null;
+			expect(foundSchool.name).to.be.equal(updatedSchoolName);
+		});
 	});
 
-	it('should throw SyncError if school could not be found', async () => {
-		const className = 'test class';
-		const system = await testObjects.createTestSystem();
-		const schoolDn = 'Not existed school dn';
-		const contentData = {
-			action: LDAP_SYNC_ACTIONS.SYNC_CLASSES,
-			syncId: '6082c4f2ba4aef3c5c4473fd',
-			data: {
-				class: {
-					name: className,
-					systemId: system._id.toString(),
-					schoolDn,
-					nameFormat: 'static',
-					ldapDN: ldapClassDn,
-					uniqueMembers: ['some uuid'],
+	describe('user messages', () => {
+		it('should create user by the data', async () => {
+			const testEmail = `test${Date.now()}@example.com`;
+			const firstName = 'test first';
+			const lastName = 'test last';
+			const ldapUserId = 'LDAP_USER_ID';
+
+			const system = await testObjects.createTestSystem();
+			const school = await testObjects.createTestSchool({ ldapSchoolIdentifier: ldapSchoolIDn, systems: [system._id] });
+
+			const contentData = {
+				action: 'syncUser',
+				syncId: '6082d22395baca4f64ef0a1f',
+				data: {
+					user: {
+						firstName,
+						lastName,
+						systemId: system._id.toString(),
+						schoolDn: school.ldapSchoolIdentifier,
+						email: testEmail,
+						ldapDn: ldapUserDn,
+						ldapId: ldapUserId,
+						roles: ['student'],
+					},
+					account: {
+						ldapDn: ldapUserDn,
+						ldapId: ldapUserId,
+						username: accountUserName,
+						systemId: system._id.toString(),
+						schoolDn: school.ldapSchoolIdentifier,
+						activated: true,
+					},
 				},
-			},
-			uniqueMembers: [null],
-		};
-		const classData = {
-			content: JSON.stringify(contentData),
-		};
-		expect(ldapConsumer.executeMessage(classData)).to.be.rejectedWith(SyncError);
+			};
+
+			const userData = {
+				content: JSON.stringify(contentData),
+			};
+			await ldapConsumer.executeMessage(userData);
+
+			const foundUser = await userModel.findOne({ ldapDn: ldapUserDn }).lean().exec();
+			expect(foundUser).to.be.not.null;
+			expect(foundUser.email).to.be.equal(testEmail);
+			expect(foundUser.firstName).to.be.equal(firstName);
+			expect(foundUser.lastName).to.be.equal(lastName);
+			expect(foundUser.ldapId).to.be.equal(ldapUserId);
+			expect(foundUser.ldapDn).to.be.equal(ldapUserDn);
+
+			const foundAccount = await accountModel.findOne({ userId: foundUser._id }).lean().exec();
+			expect(foundAccount).to.be.not.null;
+			expect(foundAccount.username).to.be.equal(accountUserName.toLowerCase());
+			expect(foundAccount.systemId.toString()).to.be.equal(system._id.toString());
+			expect(foundAccount.activated).to.be.true;
+		});
+
+		it('should update existing user by the data', async () => {
+			const initialFirstName = 'initial fname';
+			const initialLastName = 'initial lname';
+			const initialEmail = `initial_test${Date.now()}@example.com`;
+			const updatedEmail = `test${Date.now()}@example.com`;
+			const updatedFirstName = 'test first';
+			const updatedLastName = 'test last';
+			const ldapUserId = 'LDAP_USER_ID';
+
+			const system = await testObjects.createTestSystem();
+			const school = await testObjects.createTestSchool({ ldapSchoolIdentifier: ldapSchoolIDn, systems: [system._id] });
+			await testObjects.createTestUser({
+				ldapId: ldapUserId,
+				firstName: initialFirstName,
+				lastName: initialLastName,
+				email: initialEmail,
+				schoolId: school._id,
+			});
+			const contentData = {
+				action: 'syncUser',
+				syncId: '6082d22395baca4f64ef0a1f',
+				data: {
+					user: {
+						firstName: updatedFirstName,
+						lastName: updatedLastName,
+						systemId: system._id.toString(),
+						schoolDn: school.ldapSchoolIdentifier,
+						email: updatedEmail,
+						ldapDn: ldapUserDn,
+						ldapId: ldapUserId,
+						roles: ['student'],
+					},
+					account: {
+						ldapDn: ldapUserDn,
+						ldapId: ldapUserId,
+						username: accountUserName,
+						systemId: system._id.toString(),
+						schoolDn: school.ldapSchoolIdentifier,
+						activated: true,
+					},
+				},
+			};
+
+			const userData = {
+				content: JSON.stringify(contentData),
+			};
+			await ldapConsumer.executeMessage(userData);
+
+			const foundUser = await userModel.findOne({ ldapDn: ldapUserDn }).lean().exec();
+			expect(foundUser).to.be.not.null;
+			expect(foundUser.email).to.be.equal(updatedEmail);
+			expect(foundUser.firstName).to.be.equal(updatedFirstName);
+			expect(foundUser.lastName).to.be.equal(updatedLastName);
+		});
+	});
+
+	describe('class messages', () => {
+		let system;
+		let school;
+		beforeEach(async () => {
+			system = await testObjects.createTestSystem();
+			school = await testObjects.createTestSchool({ ldapSchoolIdentifier: ldapSchoolIDn, systems: [system._id] });
+		});
+		it('should create class by the data', async () => {
+			const className = 'test class';
+
+			const contentData = {
+				action: LDAP_SYNC_ACTIONS.SYNC_CLASSES,
+				syncId: '6082c4f2ba4aef3c5c4473fd',
+				data: {
+					class: {
+						name: className,
+						systemId: system._id.toString(),
+						schoolDn: school.ldapSchoolIdentifier,
+						nameFormat: 'static',
+						ldapDN: ldapClassDn,
+					},
+				},
+			};
+			const classData = {
+				content: JSON.stringify(contentData),
+			};
+			await ldapConsumer.executeMessage(classData);
+
+			const foundClass = await classModel.findOne({ ldapDN: ldapClassDn }).lean().exec();
+			expect(foundClass).to.be.not.null;
+			expect(foundClass.name).to.be.equal(className);
+			expect(foundClass.userIds).to.be.empty;
+			expect(foundClass.teacherIds).to.be.empty;
+		});
+
+		it('should update existing class by the data', async () => {
+			const initialClassName = 'initial test class';
+
+			await testObjects.createTestClass({
+				name: initialClassName,
+				ldapDN: ldapClassDn,
+				schoolId: school._id,
+				year: school.currentYear,
+			});
+
+			const updatedClassName = 'updated test class';
+			const contentData = {
+				action: LDAP_SYNC_ACTIONS.SYNC_CLASSES,
+				syncId: '6082c4f2ba4aef3c5c4473fd',
+				data: {
+					class: {
+						name: updatedClassName,
+						systemId: system._id.toString(),
+						schoolDn: school.ldapSchoolIdentifier,
+						nameFormat: 'static',
+						ldapDN: ldapClassDn,
+						uniqueMembers: ['some uuid'],
+					},
+				},
+				uniqueMembers: [null],
+			};
+			const classData = {
+				content: JSON.stringify(contentData),
+			};
+			await ldapConsumer.executeMessage(classData);
+
+			const foundClass = await classModel.findOne({ ldapDN: ldapClassDn }).lean().exec();
+			expect(foundClass).to.be.not.null;
+			expect(foundClass.name).to.be.equal(updatedClassName);
+		});
+
+		it('should create class with users by the data', async () => {
+			const className = 'test class';
+			const ldapDns = ['user1', 'user2'];
+			const contentData = {
+				action: LDAP_SYNC_ACTIONS.SYNC_CLASSES,
+				syncId: '6082c4f2ba4aef3c5c4473fd',
+				data: {
+					class: {
+						name: className,
+						systemId: system._id.toString(),
+						schoolDn: school.ldapSchoolIdentifier,
+						nameFormat: 'static',
+						ldapDN: ldapClassDn,
+						uniqueMembers: ldapDns,
+					},
+				},
+				uniqueMembers: [null],
+			};
+			const classData = {
+				content: JSON.stringify(contentData),
+			};
+			const testStudent = await testObjects.createTestUser({
+				ldapDn: ldapDns[0],
+				schoolId: school._id,
+				roles: ['student'],
+			});
+			const testTeacher = await testObjects.createTestUser({
+				ldapDn: ldapDns[1],
+				schoolId: school._id,
+				roles: ['teacher'],
+			});
+
+			await ldapConsumer.executeMessage(classData);
+
+			const foundClass = await classModel.findOne({ ldapDN: ldapClassDn }).lean().exec();
+			expect(foundClass).to.be.not.null;
+			expect(foundClass.name).to.be.equal(className);
+
+			expect(foundClass.userIds.length).to.be.equal(1);
+			expect(foundClass.teacherIds.length).to.be.equal(1);
+
+			expect(foundClass.userIds.map((userId) => userId.toString())).to.include(testStudent._id.toString());
+			expect(foundClass.teacherIds.map((userId) => userId.toString())).to.include(testTeacher._id.toString());
+		});
+
+		it('should throw SyncError if school could not be found', async () => {
+			const className = 'test class';
+			const schoolDn = 'Not existed school dn';
+			const contentData = {
+				action: LDAP_SYNC_ACTIONS.SYNC_CLASSES,
+				syncId: '6082c4f2ba4aef3c5c4473fd',
+				data: {
+					class: {
+						name: className,
+						systemId: system._id.toString(),
+						schoolDn,
+						nameFormat: 'static',
+						ldapDN: ldapClassDn,
+						uniqueMembers: ['some uuid'],
+					},
+				},
+				uniqueMembers: [null],
+			};
+			const classData = {
+				content: JSON.stringify(contentData),
+			};
+			expect(ldapConsumer.executeMessage(classData)).to.be.rejectedWith(SyncError);
+		});
 	});
 });

--- a/test/services/sync/strategies/LDAPSyncerConsumer.test.js
+++ b/test/services/sync/strategies/LDAPSyncerConsumer.test.js
@@ -36,7 +36,7 @@ describe('Ldap Syncer Consumer', () => {
 				action: TEST_ACTION_TYPE,
 				content: 'test message',
 			};
-			expect(ldapConsumer.executeMessage(msg)).to.eventually.throw(BadRequest);
+			await expect(ldapConsumer.executeMessage(msg)).to.be.rejectedWith(BadRequest);
 		});
 	});
 });

--- a/test/services/sync/strategies/LDAPSyncerConsumer.test.js
+++ b/test/services/sync/strategies/LDAPSyncerConsumer.test.js
@@ -34,7 +34,7 @@ describe('Ldap Syncer Consumer', () => {
 			const ldapConsumer = new LDAPSyncerConsumer();
 			const msg = {
 				action: TEST_ACTION_TYPE,
-				content: 'test message',
+				content: JSON.stringify({ res: 'test message' }),
 			};
 			await expect(ldapConsumer.executeMessage(msg)).to.be.rejectedWith(BadRequest);
 		});

--- a/test/services/sync/strategies/consumerActions/ClassAction.test.js
+++ b/test/services/sync/strategies/consumerActions/ClassAction.test.js
@@ -7,7 +7,7 @@ const { ObjectId } = require('mongoose').Types;
 const { BadRequest, NotFound } = require('../../../../../src/errors');
 const { ClassAction } = require('../../../../../src/services/sync/strategies/consumerActions');
 
-const { SchoolRepo, ClassRepo } = require('../../../../../src/services/sync/repo');
+const { SchoolRepo, ClassRepo, UserRepo } = require('../../../../../src/services/sync/repo');
 
 const { expect } = chai;
 chai.use(chaiAsPromised);
@@ -27,7 +27,7 @@ describe('Class Actions', () => {
 		const testSchoolName = 'Test School';
 		it('should create class if not exists', async () => {
 			const findSchoolByLdapIdAndSystemStub = sinon.stub(SchoolRepo, 'findSchoolByLdapIdAndSystem');
-			const schoolId = 1;
+			const schoolId = new ObjectId();
 			const className = 'Class Name';
 			const ldapDn = 'some ldap';
 			const currentYear = new ObjectId();
@@ -78,6 +78,83 @@ describe('Class Actions', () => {
 			const findSchoolByLdapIdAndSystemStub = sinon.stub(SchoolRepo, 'findSchoolByLdapIdAndSystem');
 			findSchoolByLdapIdAndSystemStub.returns(null);
 			expect(classAction.action({ class: { schoolDn: 'SCHOOL_DN', systemId: '' } })).to.be.rejectedWith(NotFound);
+		});
+	});
+
+	describe('addUsersToClass', () => {
+		let updateClassStudentsStub;
+		let updateClassTeachersStub;
+		const mockClass = {
+			_id: new ObjectId(),
+		};
+		beforeEach(() => {
+			const findClassByYearAndLdapDnStub = sinon.stub(ClassRepo, 'findClassByYearAndLdapDn');
+			findClassByYearAndLdapDnStub.returns(mockClass);
+
+			updateClassStudentsStub = sinon.stub(ClassRepo, 'updateClassStudents');
+			updateClassTeachersStub = sinon.stub(ClassRepo, 'updateClassTeachers');
+		});
+
+		afterEach(() => sinon.restore());
+
+		it('should add single user to the class', async () => {
+			const uniqueMembers = 'user1';
+			const classData = {
+				ldapDn: 'TEST_CLASS',
+				uniqueMembers,
+			};
+
+			const foundUsers = [
+				{
+					_id: 'user1',
+					roles: [{ name: 'student' }],
+				},
+			];
+			const findByLdapDnAndSchoolStub = sinon.stub(UserRepo, 'findByLdapDnAndSchool');
+			findByLdapDnAndSchoolStub.returns(foundUsers);
+
+			const schoolObj = { _id: new ObjectId(), currentYear: new ObjectId() };
+			await classAction.addUsersToClass(classData, schoolObj);
+
+			expect(updateClassStudentsStub.calledOnce).to.be.true;
+			expect(updateClassStudentsStub.getCall(0).firstArg.toString()).to.be.equal(mockClass._id.toString());
+			expect(updateClassStudentsStub.getCall(0).lastArg).to.eql(['user1']);
+		});
+
+		it('should add students and teachers to the class', async () => {
+			const uniqueMembers = ['user1', 'user2', 'user3'];
+			const classData = {
+				ldapDn: 'TEST_CLASS',
+				uniqueMembers,
+			};
+
+			const foundUsers = [
+				{
+					_id: 'user1',
+					roles: [{ name: 'student' }],
+				},
+				{
+					_id: 'user2',
+					roles: [{ name: 'student' }, { name: 'teacher' }], // Should this case exists?
+				},
+				{
+					_id: 'user3',
+					roles: [{ name: 'teacher' }],
+				},
+			];
+			const findByLdapDnAndSchoolStub = sinon.stub(UserRepo, 'findByLdapDnAndSchool');
+			findByLdapDnAndSchoolStub.returns(foundUsers);
+
+			const schoolObj = { _id: new ObjectId(), currentYear: new ObjectId() };
+			await classAction.addUsersToClass(classData, schoolObj);
+
+			expect(updateClassStudentsStub.calledOnce).to.be.true;
+			expect(updateClassStudentsStub.getCall(0).firstArg.toString()).to.be.equal(mockClass._id.toString());
+			expect(updateClassStudentsStub.getCall(0).lastArg).to.eql(['user1', 'user2']);
+
+			expect(updateClassTeachersStub.calledOnce).to.be.true;
+			expect(updateClassTeachersStub.getCall(0).firstArg.toString()).to.be.equal(mockClass._id.toString());
+			expect(updateClassTeachersStub.getCall(0).lastArg).to.eql(['user2', 'user3']);
 		});
 	});
 });

--- a/test/services/sync/strategies/consumerActions/ClassAction.test.js
+++ b/test/services/sync/strategies/consumerActions/ClassAction.test.js
@@ -71,13 +71,13 @@ describe('Class Actions', () => {
 			const findClassByYearAndLdapDnStub = sinon.stub(ClassRepo, 'findClassByYearAndLdapDn');
 			findClassByYearAndLdapDnStub.throws(new BadRequest('class repo error'));
 
-			expect(classAction.action({})).to.be.rejectedWith(BadRequest);
+			await expect(classAction.action({})).to.be.rejectedWith(BadRequest);
 		});
 
 		it('should throw an error if school could not be found', async () => {
 			const findSchoolByLdapIdAndSystemStub = sinon.stub(SchoolRepo, 'findSchoolByLdapIdAndSystem');
 			findSchoolByLdapIdAndSystemStub.returns(null);
-			expect(classAction.action({ class: { schoolDn: 'SCHOOL_DN', systemId: '' } })).to.be.rejectedWith(NotFound);
+			await expect(classAction.action({ class: { schoolDn: 'SCHOOL_DN', systemId: '' } })).to.be.rejectedWith(NotFound);
 		});
 	});
 

--- a/test/services/sync/strategies/consumerActions/ClassAction.test.js
+++ b/test/services/sync/strategies/consumerActions/ClassAction.test.js
@@ -37,6 +37,7 @@ describe('Class Actions', () => {
 			findClassByYearAndLdapDnStub.returns(null);
 
 			const createClassStub = sinon.stub(ClassRepo, 'createClass');
+			createClassStub.returns({ _id: new ObjectId() });
 			await classAction.action({ class: { name: className, ldapDN: ldapDn } });
 			expect(createClassStub.calledOnce).to.be.true;
 
@@ -49,7 +50,7 @@ describe('Class Actions', () => {
 
 		it('should update class name for existing class', async () => {
 			const findSchoolByLdapIdAndSystemStub = sinon.stub(SchoolRepo, 'findSchoolByLdapIdAndSystem');
-			const classId = 1;
+			const classId = new ObjectId();
 			findSchoolByLdapIdAndSystemStub.returns({ name: testSchoolName });
 
 			const findClassByYearAndLdapDnStub = sinon.stub(ClassRepo, 'findClassByYearAndLdapDn');
@@ -99,10 +100,6 @@ describe('Class Actions', () => {
 
 		it('should add single user to the class', async () => {
 			const uniqueMembers = 'user1';
-			const classData = {
-				ldapDn: 'TEST_CLASS',
-				uniqueMembers,
-			};
 
 			const foundUsers = [
 				{
@@ -114,7 +111,7 @@ describe('Class Actions', () => {
 			findByLdapDnsAndSchoolStub.returns(foundUsers);
 
 			const schoolObj = { _id: new ObjectId(), currentYear: new ObjectId() };
-			await classAction.addUsersToClass(classData, schoolObj);
+			await classAction.addUsersToClass(schoolObj._id, mockClass._id, uniqueMembers);
 
 			expect(updateClassStudentsStub.calledOnce).to.be.true;
 			expect(updateClassStudentsStub.getCall(0).firstArg.toString()).to.be.equal(mockClass._id.toString());
@@ -123,10 +120,6 @@ describe('Class Actions', () => {
 
 		it('should add students and teachers to the class', async () => {
 			const uniqueMembers = ['user1', 'user2', 'user3'];
-			const classData = {
-				ldapDn: 'TEST_CLASS',
-				uniqueMembers,
-			};
 
 			const foundUsers = [
 				{
@@ -146,7 +139,7 @@ describe('Class Actions', () => {
 			findByLdapDnsAndSchoolStub.returns(foundUsers);
 
 			const schoolObj = { _id: new ObjectId(), currentYear: new ObjectId() };
-			await classAction.addUsersToClass(classData, schoolObj);
+			await classAction.addUsersToClass(schoolObj._id, mockClass._id, uniqueMembers);
 
 			expect(updateClassStudentsStub.calledOnce).to.be.true;
 			expect(updateClassStudentsStub.getCall(0).firstArg.toString()).to.be.equal(mockClass._id.toString());

--- a/test/services/sync/strategies/consumerActions/ClassAction.test.js
+++ b/test/services/sync/strategies/consumerActions/ClassAction.test.js
@@ -110,8 +110,8 @@ describe('Class Actions', () => {
 					roles: [{ name: 'student' }],
 				},
 			];
-			const findByLdapDnAndSchoolStub = sinon.stub(UserRepo, 'findByLdapDnAndSchool');
-			findByLdapDnAndSchoolStub.returns(foundUsers);
+			const findByLdapDnsAndSchoolStub = sinon.stub(UserRepo, 'findByLdapDnsAndSchool');
+			findByLdapDnsAndSchoolStub.returns(foundUsers);
 
 			const schoolObj = { _id: new ObjectId(), currentYear: new ObjectId() };
 			await classAction.addUsersToClass(classData, schoolObj);
@@ -142,8 +142,8 @@ describe('Class Actions', () => {
 					roles: [{ name: 'teacher' }],
 				},
 			];
-			const findByLdapDnAndSchoolStub = sinon.stub(UserRepo, 'findByLdapDnAndSchool');
-			findByLdapDnAndSchoolStub.returns(foundUsers);
+			const findByLdapDnsAndSchoolStub = sinon.stub(UserRepo, 'findByLdapDnsAndSchool');
+			findByLdapDnsAndSchoolStub.returns(foundUsers);
 
 			const schoolObj = { _id: new ObjectId(), currentYear: new ObjectId() };
 			await classAction.addUsersToClass(classData, schoolObj);

--- a/test/services/sync/strategies/consumerActions/SchoolAction.test.js
+++ b/test/services/sync/strategies/consumerActions/SchoolAction.test.js
@@ -3,7 +3,6 @@ const chaiAsPromised = require('chai-as-promised');
 
 const sinon = require('sinon');
 const { BadRequest } = require('../../../../../src/errors');
-const { SyncError } = require('../../../../../src/errors/applicationErrors');
 const { SchoolAction } = require('../../../../../src/services/sync/strategies/consumerActions');
 
 const { SchoolRepo } = require('../../../../../src/services/sync/repo');
@@ -54,7 +53,7 @@ describe('School Actions', () => {
 		it('should throw a sync error if school repo throws an error', async () => {
 			const findSchoolByLdapIdAndSystemStub = sinon.stub(SchoolRepo, 'findSchoolByLdapIdAndSystem');
 			findSchoolByLdapIdAndSystemStub.throws(new BadRequest('school repo error'));
-			await expect(schoolAction.action({})).to.be.rejectedWith(SyncError);
+			await expect(schoolAction.action({})).to.be.rejectedWith(BadRequest);
 		});
 	});
 });

--- a/test/services/sync/strategies/consumerActions/SchoolAction.test.js
+++ b/test/services/sync/strategies/consumerActions/SchoolAction.test.js
@@ -54,7 +54,7 @@ describe('School Actions', () => {
 		it('should throw a sync error if school repo throws an error', async () => {
 			const findSchoolByLdapIdAndSystemStub = sinon.stub(SchoolRepo, 'findSchoolByLdapIdAndSystem');
 			findSchoolByLdapIdAndSystemStub.throws(new BadRequest('school repo error'));
-			expect(schoolAction.action({})).to.eventually.throw(SyncError);
+			await expect(schoolAction.action({})).to.be.rejectedWith(SyncError);
 		});
 	});
 });

--- a/test/services/sync/strategies/consumerActions/UserAction.test.js
+++ b/test/services/sync/strategies/consumerActions/UserAction.test.js
@@ -96,13 +96,13 @@ describe('User Actions', () => {
 			const findByLdapIdAndSchoolStub = sinon.stub(UserRepo, 'findByLdapIdAndSchool');
 			findByLdapIdAndSchoolStub.throws(new BadRequest('class repo error'));
 
-			expect(userAction.action({ user: {}, account: {} })).to.be.rejectedWith(BadRequest);
+			await expect(userAction.action({ user: {}, account: {} })).to.be.rejectedWith(BadRequest);
 		});
 
 		it('should throw an error if school could not be found', async () => {
 			const findSchoolByLdapIdAndSystemStub = sinon.stub(SchoolRepo, 'findSchoolByLdapIdAndSystem');
 			findSchoolByLdapIdAndSystemStub.returns(null);
-			expect(userAction.action({ class: { schoolDn: 'SCHOOL_DN', systemId: '' } })).to.be.rejectedWith(NotFound);
+			await expect(userAction.action({ class: { schoolDn: 'SCHOOL_DN', systemId: '' } })).to.be.rejectedWith(NotFound);
 		});
 	});
 });


### PR DESCRIPTION
# Description
The sync of Students and Teachers where forgotten, re add it.

## Links to Tickets or other pull requests
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/2460
- https://ticketsystem.hpi-schul-cloud.org/browse/SC-8898

## Changes
- Re add missing Studetns and Teahcer snc to a classes

## Datasecurity <sub><sup>details [on Confluence](https://docs.hpi-schul-cloud.org/x/2S3GBg)</sup></sub>

## Deployment

## New Repos, NPM pakages or vendor scripts

## Approval for review
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
