### PR TITLE
[OPS-2418] add E2E tests only for PRs on feature branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ branches:
 
 stages:
   - name: test
-    if: NOT (commit_message =~ /(skip-test-stage)/ ) OR branch = /^(feature).*$/ AND "$TRAVIS_PULL_REQUEST" != "false"
+    if: NOT ((commit_message =~ /(skip-test-stage)/ ) OR branch = /^(feature).*$/ AND "$TRAVIS_PULL_REQUEST" != "false" (
   - name: deploy
     if: NOT (commit_message =~ /(skip-deploy-stage)/)
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,13 @@ services:
 
 branches:
   only:
-    - develop
-    - master
-     - /^(release).*$/
+    - /^(release).*$/
     # OPS-1664 naming convention <branch>/<JIRA-Ticket ID>-<Jira_Summary>
-    - /^((hotfix|feature)\/[A-Z]+-[0-9]+-[a-zA-Z_]+)$/
+    - /^(feature\/[A-Z]+-[0-9]+-[a-zA-Z_]+)$/
 
 stages:
   - name: test
-    if: NOT (commit_message =~ /(skip-test-stage)/ ) or branch = master
+    if: NOT (commit_message =~ /(skip-test-stage)/ ) OR branch = /^(feature).*$/ AND "$TRAVIS_PULL_REQUEST" != "false"
   - name: deploy
     if: NOT (commit_message =~ /(skip-deploy-stage)/)
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,15 @@ services:
 
 branches:
   only:
+    - develop
+    - master    
     - /^(release).*$/
     # OPS-1664 naming convention <branch>/<JIRA-Ticket ID>-<Jira_Summary>
     - /^(feature\/[A-Z]+-[0-9]+-[a-zA-Z0-9_]+)$/
 
 stages:
   - name: test
-    if: NOT ( (commit_message =~ /(skip-test-stage)/ ) OR branch = /^(feature).*$/ AND "$TRAVIS_PULL_REQUEST" != "false" )
+    if: NOT NOT ( (commit_message =~ /(skip-test-stage)/ ) OR branch = master OR branch = develop OR branch = /^(feature).*$/ AND "$TRAVIS_PULL_REQUEST" != "false" )
   - name: deploy
     if: NOT (commit_message =~ /(skip-deploy-stage)/)
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ branches:
 
 stages:
   - name: test
-    if: NOT ((commit_message =~ /(skip-test-stage)/ ) OR branch = /^(feature).*$/ AND "$TRAVIS_PULL_REQUEST" != "false" (
+    if: NOT ( (commit_message =~ /(skip-test-stage)/ ) OR branch = /^(feature).*$/ AND "$TRAVIS_PULL_REQUEST" != "false" )
   - name: deploy
     if: NOT (commit_message =~ /(skip-deploy-stage)/)
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
   only:
     - /^(release).*$/
     # OPS-1664 naming convention <branch>/<JIRA-Ticket ID>-<Jira_Summary>
-    - /^(feature\/[A-Z]+-[0-9]+-[a-zA-Z_]+)$/
+    - /^(feature\/[A-Z]+-[0-9]+-[a-zA-Z0-9_]+)$/
 
 stages:
   - name: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Added
 
+- OPS-2418 - Change buildpipelines (Server, Client, Nuxt) to execute E2E tests according QF decision
 - SC-8250 - add bulk deletion to user service v2
 - SC-8341 - add tombstone school to tombstone user
 - SC-8408 - added delete events by scope Id route

--- a/build.sh
+++ b/build.sh
@@ -34,10 +34,10 @@ then
 elif [[ "$TRAVIS_BRANCH" =~ ^"release"* ]]
 then
 	GIT_FLOW_BRANCH="release"
-elif [[ "$TRAVIS_BRANCH" =~ ^hotfix\/[A-Z]+-[0-9]+-[a-zA-Z_]+$ ]]
+elif [[ "$TRAVIS_BRANCH" =~ ^hotfix\/[A-Z]+-[0-9]+-[a-zA-Z0-9_]+$ ]]
 then
 	GIT_FLOW_BRANCH="hotfix"
-elif [[ "$TRAVIS_BRANCH" =~ ^feature\/[A-Z]+-[0-9]+-[a-zA-Z_]+$ ]]
+elif [[ "$TRAVIS_BRANCH" =~ ^feature\/[A-Z]+-[0-9]+-[a-zA-Z0-9_]+$ ]]
 then
 	GIT_FLOW_BRANCH="feature"
 else
@@ -97,15 +97,15 @@ echo DOCKERTAG_SHA="$DOCKERTAG_SHA"
 
 function buildandpush {
 	# build containers
+	# Log in to the docker CLI
+	echo "$MY_DOCKER_PASSWORD" | docker login -u "$DOCKER_ID" --password-stdin
+	
 	docker build -t schulcloud/schulcloud-server:"$DOCKERTAG" -t schulcloud/schulcloud-server:"$DOCKERTAG_SHA" .
 
 	if [[ "$?" != "0" ]]
 	then
 		exit $?
 	fi
-
-	# Log in to the docker CLI
-	echo "$MY_DOCKER_PASSWORD" | docker login -u "$DOCKER_ID" --password-stdin
 
 	# take those images and push them up to docker hub
 	docker push schulcloud/schulcloud-server:"$DOCKERTAG"


### PR DESCRIPTION
# Description
Change buildpipelines (Server, Client, Nuxt) to execute E2E tests according QF decision

## Links to Tickets or other pull requests
- https://ticketsystem.hpi-schul-cloud.org/browse/OPS-2418
- https://docs.hpi-schul-cloud.org/display/TSC/Deployment+to+test%2C+staging+and+hotfix?src=jira

## Changes
enable the execution of E2E tests according to the confluence table
update the table with implementation status

NOT in Fix
the evaluation of suppressing E2E tests in PRs based on label presence (OPS-2419)
the implementation of a GitHub workflow to manually execute E2E tests (OPS-2420)

## Datasecurity <sub><sup>details [on Confluence](https://docs.hpi-schul-cloud.org/x/2S3GBg)</sup></sub>
none

## Deployment
none

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
