### PR TITLE
remove unneccesary timeout rules replaced by correct promise handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Changed 
 
+- remove unneccesary timeout definitions from tests and avoid promise chains
 - SC-6294 Restructure NestJS Sources: Testing, Core Module, Entities, Shared. See details in https://hpi-schul-cloud.github.io/schulcloud-server/
 
 ## [26.4.4] - 2021-06-16

--- a/TODO.md
+++ b/TODO.md
@@ -34,7 +34,7 @@
 ## SELECTED
 
 - test shared / core module 
-- async test fixes
+- async test fixes (remove this.timeout and red promise chains)
 
 - db configuration
 

--- a/apps/server/doc/testing.md
+++ b/apps/server/doc/testing.md
@@ -55,6 +55,69 @@ describe("Course Service", (() => {
 });
 ```
 
+### Handling of function return values
+
+When assigning a value to an expect, separate the function call from the expectation to simplify debugging. This later helps when you not know about the return value type or if it's an promise or not. This is good style not only for tests.
+
+```TypeScript
+	// doSomethingCrazy : retValue
+	it('bad sample', () => {
+		expect(doSomethingCrazy(x,y,z)).to... 
+	})
+	it('good sample', () => {
+		const result = doSomethingCrazy(x,y,z)
+		expect(result).to... // here we can simply debug
+	})
+
+```
+
+### Promises and tests
+
+When using asynchronous functions and/opr promises, results must be awaited within of an async test function instead of using promise chains. While for expexting error conditions it might be helpful to use catch for extracting a value from an expected error, in every case avoid writing long promise chains. 
+
+ - Instead of using done callback, use async test functions. 
+ - Use await instead of (long) promise chains 
+
+```TypeScript
+	// doSomethingCrazy : Promise<retValue>
+	it('bad async sample', async (done) => {
+		return doSomethingCrazy(x,y,z).then(result=>{
+			expect(result).to...
+			done() // expected done
+		}).catch(()=>{
+			logger.info(`Could not ... ${error}`);
+			done() // unexpected done, test will always succeed which is wrong
+		})
+	})
+	it('good async sample', async () => {
+		const result = await doSomethingCrazy(x,y,z)
+		expect(result).to...
+	})
+``` 
+
+> Timeouts must not be used, when async handling is correctly defined!
+
+### Expecting errors in tests
+
+When expecting an error, you might take values from an error, test for the error type thrown and must care of promises.
+
+```TypeScript
+	// doSomethingCrazy : Promise<retValue>
+	it('bad async sample expecting an error', async () => {
+		expect(doSomethingCrazy(x,y,z)).to...
+	})
+	it('good async sample expecting an error value', async () => {
+		const code = await doSomethingCrazy(x,y,z).catch(err => err.code)
+		expect(code).to...
+	})
+	it('good sample expecting an error type', async () => {
+		expect(() => doSomethingCrazySync(wrong, param)).toThrow(BadRequestException);
+	})
+	it('good sample expecting an error type from an async function', async () => {
+		await expect(() => doSomethingCrazySync(wrong, param)).toThrow(BadRequestException);
+	})
+```
+
 ### Isolation
 
 Each test should be able to run alone, as well as together with any other tests. To ensure this, it is important that the test does not depend on any preexisting data.

--- a/apps/server/doc/testing.md
+++ b/apps/server/doc/testing.md
@@ -110,11 +110,11 @@ When expecting an error, you might take values from an error, test for the error
 		const code = await doSomethingCrazy(x,y,z).catch(err => err.code)
 		expect(code).to...
 	})
-	it('good sample expecting an error type', async () => {
+	it('good sample expecting an error type from a sync function', () => {
 		expect(() => doSomethingCrazySync(wrong, param)).toThrow(BadRequestException);
 	})
 	it('good sample expecting an error type from an async function', async () => {
-		await expect(() => doSomethingCrazySync(wrong, param)).toThrow(BadRequestException);
+		await expect(doSomethingCrazySync(wrong, param)).rejects.toThrow(BadRequestException);
 	})
 ```
 

--- a/apps/server/doc/testing.md
+++ b/apps/server/doc/testing.md
@@ -71,16 +71,18 @@ When assigning a value to an expect, separate the function call from the expecta
 
 ```
 
-### Promises and tests
+### Promises and Timouts in tests
 
 When using asynchronous functions and/opr promises, results must be awaited within of an async test function instead of using promise chains. While for expexting error conditions it might be helpful to use catch for extracting a value from an expected error, in every case avoid writing long promise chains. 
 
  - Instead of using done callback, use async test functions. 
  - Use await instead of (long) promise chains 
+ - never manually set a timeout
 
 ```TypeScript
 	// doSomethingCrazy : Promise<retValue>
-	it('bad async sample', async (done) => {
+	it('bad async sample', async function (done) => {
+		this.timeout(10000);
 		return doSomethingCrazy(x,y,z).then(result=>{
 			expect(result).to...
 			done() // expected done
@@ -90,6 +92,7 @@ When using asynchronous functions and/opr promises, results must be awaited with
 		})
 	})
 	it('good async sample', async () => {
+		// no timeout set
 		const result = await doSomethingCrazy(x,y,z)
 		expect(result).to...
 	})

--- a/apps/server/doc/testing.md
+++ b/apps/server/doc/testing.md
@@ -55,6 +55,26 @@ describe("Course Service", (() => {
 });
 ```
 
+### Isolation
+
+Each test should be able to run alone, as well as together with any other tests. To ensure this, it is important that the test does not depend on any preexisting data.
+
+- Each test should generate the data it needs, and ensure that its data is deleted afterwards. (this is usually done via mocha's "afterEach" function.
+- When you create objects with fields that have to be globally unique, like the account username, you must ensure the name you choose is unique. This can be done by including a timestamp.
+- Never use seeddata.
+
+### Test Structure
+
+Your test should be structured in three seperate areas, each distinguished by at least an empty line:
+
+- Arrange - set up your testdata
+- Act - call the function you want to test
+- Assert - check the result
+
+this is known as the AAA-pattern.
+
+## Testing Samples
+
 ### Handling of function return values
 
 When assigning a value to an expect, separate the function call from the expectation to simplify debugging. This later helps when you not know about the return value type or if it's an promise or not. This is good style not only for tests.
@@ -62,7 +82,7 @@ When assigning a value to an expect, separate the function call from the expecta
 ```TypeScript
 	// doSomethingCrazy : retValue
 	it('bad sample', () => {
-		expect(doSomethingCrazy(x,y,z)).to... 
+		expect(doSomethingCrazy(x,y,z)).to...
 	})
 	it('good sample', () => {
 		const result = doSomethingCrazy(x,y,z)
@@ -73,11 +93,11 @@ When assigning a value to an expect, separate the function call from the expecta
 
 ### Promises and Timouts in tests
 
-When using asynchronous functions and/opr promises, results must be awaited within of an async test function instead of using promise chains. While for expexting error conditions it might be helpful to use catch for extracting a value from an expected error, in every case avoid writing long promise chains. 
+When using asynchronous functions and/opr promises, results must be awaited within of an async test function instead of using promise chains. While for expexting error conditions it might be helpful to use catch for extracting a value from an expected error, in every case avoid writing long promise chains.
 
- - Instead of using done callback, use async test functions. 
- - Use await instead of (long) promise chains 
- - never manually set a timeout
+- Instead of using done callback, use async test functions.
+- Use await instead of (long) promise chains
+- never manually set a timeout
 
 ```TypeScript
 	// doSomethingCrazy : Promise<retValue>
@@ -96,7 +116,7 @@ When using asynchronous functions and/opr promises, results must be awaited with
 		const result = await doSomethingCrazy(x,y,z)
 		expect(result).to...
 	})
-``` 
+```
 
 > Timeouts must not be used, when async handling is correctly defined!
 
@@ -106,7 +126,7 @@ When expecting an error, you might take values from an error, test for the error
 
 ```TypeScript
 	// doSomethingCrazy : Promise<retValue>
-	it('bad async sample expecting an error', async () => {
+	it('bad async sample expecting an error', () => {
 		expect(doSomethingCrazy(x,y,z)).to...
 	})
 	it('good async sample expecting an error value', async () => {
@@ -120,24 +140,6 @@ When expecting an error, you might take values from an error, test for the error
 		await expect(doSomethingCrazySync(wrong, param)).rejects.toThrow(BadRequestException);
 	})
 ```
-
-### Isolation
-
-Each test should be able to run alone, as well as together with any other tests. To ensure this, it is important that the test does not depend on any preexisting data.
-
-- Each test should generate the data it needs, and ensure that its data is deleted afterwards. (this is usually done via mocha's "afterEach" function.
-- When you create objects with fields that have to be globally unique, like the account username, you must ensure the name you choose is unique. This can be done by including a timestamp.
-- Never use seeddata.
-
-### Test Structure
-
-Your test should be structured in three seperate areas, each distinguished by at least an empty line:
-
-- Arrange - set up your testdata
-- Act - call the function you want to test
-- Assert - check the result
-
-this is known as the AAA-pattern.
 
 ## Testing Utilities
 
@@ -318,7 +320,7 @@ are correctly mounted and available at a specific path.
 
 > Do not test logic (from the business layer or repository) in e2e-tests, this must be done where the logic is defined within of a unit test. A e2e test should only ensure everything is correctly initialized.
 
-> Do not put logic (beside statements, transactions, mapping) inside a controller, use the logic layer instead. 
+> Do not put logic (beside statements, transactions, mapping) inside a controller, use the logic layer instead.
 
 > Mappers must be unit tested.
 

--- a/test/app.hooks.redis.test.js
+++ b/test/app.hooks.redis.test.js
@@ -5,9 +5,7 @@ const redisMock = require('./utils/redis/redisMock');
 
 const { Configuration } = commons; // separated from require, mocked in tests
 
-describe('handleAutoLogout hook', function test() {
-	this.timeout(20000);
-
+describe('handleAutoLogout hook', () => {
 	let fut;
 	let redisHelper;
 	let configBefore;

--- a/test/jobs/rss-news/index.integration.test.js
+++ b/test/jobs/rss-news/index.integration.test.js
@@ -7,15 +7,11 @@ const { exec } = require('child_process');
 const { schoolModel } = require('../../../src/services/school/model');
 const { newsModel } = require('../../../src/services/news/model');
 
-
 const { expect } = chai;
 
 function runWorker() {
 	return new Promise((resolve, reject) => {
-		const child = exec(
-			`node ${path.join(__dirname, '../../../src/jobs/rss-news.js')}`,
-			{ env: { ...process.env } },
-		);
+		const child = exec(`node ${path.join(__dirname, '../../../src/jobs/rss-news.js')}`, { env: { ...process.env } });
 
 		child.on('exit', resolve);
 		child.on('error', reject);
@@ -24,9 +20,7 @@ function runWorker() {
 	});
 }
 
-describe('RSS Feed Crawler Integration', function () {
-	this.timeout(10000)
-	
+describe('RSS Feed Crawler Integration', () => {
 	const mockPort = 3039;
 	let mockServer;
 
@@ -84,11 +78,10 @@ describe('RSS Feed Crawler Integration', function () {
 	});
 
 	before(async function () {
-		 sampleSchool = await schoolModel.findOneAndUpdate(
-			{},
-			{ $set: { rssFeeds: [sampleRSSFeed] } },
-			{ new: true },
-		).lean().exec();
+		sampleSchool = await schoolModel
+			.findOneAndUpdate({}, { $set: { rssFeeds: [sampleRSSFeed] } }, { new: true })
+			.lean()
+			.exec();
 	});
 
 	beforeEach(runWorker);
@@ -104,7 +97,7 @@ describe('RSS Feed Crawler Integration', function () {
 	it('should set rssFeed status to success', async () => {
 		const school = (await schoolModel.findById(sampleSchool._id)).toObject();
 
-		const successRSSFeed = school.rssFeeds.find(el => el.url === sampleRSSFeed.url);
+		const successRSSFeed = school.rssFeeds.find((el) => el.url === sampleRSSFeed.url);
 		expect(successRSSFeed.status).to.equal('success');
 	});
 
@@ -121,7 +114,7 @@ describe('RSS Feed Crawler Integration', function () {
 		it('should set rssFeed status to error for invalid urls', async () => {
 			const school = (await schoolModel.findById(sampleSchool._id)).toObject();
 
-			const errorRSSFeed = school.rssFeeds.find(el => el.url === invalidFeed.url);
+			const errorRSSFeed = school.rssFeeds.find((el) => el.url === invalidFeed.url);
 			expect(errorRSSFeed.status).to.equal('error');
 		});
 	});
@@ -129,11 +122,7 @@ describe('RSS Feed Crawler Integration', function () {
 	describe('Override changed news', () => {
 		const changedContent = 'test';
 		before(async () => {
-			dbRSSNews = await newsModel.findByIdAndUpdate(
-				dbRSSNews._id,
-				{ content: changedContent },
-				{ new: true },
-			);
+			dbRSSNews = await newsModel.findByIdAndUpdate(dbRSSNews._id, { content: changedContent }, { new: true });
 		});
 
 		it('should override changed news', async () => {

--- a/test/services/account/iserv/iserv.test.js
+++ b/test/services/account/iserv/iserv.test.js
@@ -7,33 +7,29 @@ const config = require('./config');
 chai.use(chaiHttp);
 const { expect } = chai;
 
-describe('IServ single-sign-on', function () {
-	this.timeout(5000);
-
+describe('IServ single-sign-on', () => {
 	let mockSystem = null;
 
 	function createIServMockServer() {
 		return iservMockServer();
 	}
 
-	before(() =>
-		createIServMockServer().then((iserv) => {
-			mockSystem = {
-				url: iserv.url,
-				oaClientId: 'test',
-				oaClientSecret: 'test',
-			};
-		})
-	);
+	before(async () => {
+		const iserv = await createIServMockServer();
 
-	it('should succeed when input with correct credentials', () => {
+		mockSystem = {
+			url: iserv.url,
+			oaClientId: 'test',
+			oaClientSecret: 'test',
+		};
+	});
+
+	it('should succeed when input with correct credentials', async () => {
 		const loginService = new IservStrategy();
 		const { username, password } = config.testIServUser;
-		return loginService.credentialCheck(username, password, mockSystem).then((response) => {
-			const _res = response;
-			expect(_res).to.be.not.undefined;
-			expect(_res.data.statusCode).to.equal('200');
-		});
+		const response = await loginService.credentialCheck(username, password, mockSystem);
+		expect(response).to.be.not.undefined;
+		expect(response.data.statusCode).to.equal('200');
 	});
 
 	it('should fail when input wrong user credentials', () => {

--- a/test/services/authentication/authentication.integration.test.js
+++ b/test/services/authentication/authentication.integration.test.js
@@ -7,12 +7,11 @@ const { Configuration } = commons;
 chai.use(chaiHttp);
 const { expect } = chai;
 
-describe('authentication service integration tests', function test() {
+describe('authentication service integration tests', () => {
 	let app;
 	let server;
 	let configBefore;
 	let testObjects;
-	this.timeout(10000);
 
 	before(async () => {
 		delete require.cache[require.resolve('../../../src/app')];

--- a/test/services/authentication/hooks/index.test.js
+++ b/test/services/authentication/hooks/index.test.js
@@ -5,8 +5,7 @@ const commons = require('@hpi-schul-cloud/commons');
 const { Configuration } = commons;
 const redisMock = require('../../../utils/redis/redisMock');
 
-describe('authentication hooks', function test() {
-	this.timeout(20000);
+describe('authentication hooks', () => {
 	let redisHelper;
 	let addJwtToWhitelist;
 	let removeJwtFromWhitelist;

--- a/test/services/calendar/index.test.js
+++ b/test/services/calendar/index.test.js
@@ -6,9 +6,7 @@ const mockery = require('mockery');
 
 const requestMock = require('./mock/mockResponses');
 
-describe('calendar service', function () {
-	this.timeout(20000); // for slow require(app) call
-
+describe('calendar service', () => {
 	let app = null;
 	let calendarService = null;
 
@@ -35,23 +33,22 @@ describe('calendar service', function () {
 		assert.ok(calendarService);
 	});
 
-	it('GET /calendar', () =>
-		calendarService
-			.find({
-				query: { all: true },
-				payload: { userId: '0000d231816abba584714c9e' },
-			})
-			.then((result) => {
-				expect(result.length).to.be.above(0);
-				expect(result[0].title).to.not.be.undefined;
-				expect(result[0].title).to.equal('tttttt');
-				expect(result[0].start).to.not.be.undefined;
-				expect(result[0].start).to.equal(1495224000000);
-				expect(result[0].end).to.not.be.undefined;
-				expect(result[0].end).to.equal(1495224000000);
-			}));
+	it('GET /calendar', async () => {
+		const result = await calendarService.find({
+			query: { all: true },
+			payload: { userId: '0000d231816abba584714c9e' },
+		});
 
-	it('POST /calendar', () => {
+		expect(result.length).to.be.above(0);
+		expect(result[0].title).to.not.be.undefined;
+		expect(result[0].title).to.equal('tttttt');
+		expect(result[0].start).to.not.be.undefined;
+		expect(result[0].start).to.equal(1495224000000);
+		expect(result[0].end).to.not.be.undefined;
+		expect(result[0].end).to.equal(1495224000000);
+	});
+
+	it('POST /calendar', async () => {
 		const postBody = {
 			summary: 'ttt',
 			location: 'Paul-Gerhardt-Gymnasium',
@@ -61,12 +58,11 @@ describe('calendar service', function () {
 			scopeId: '0000d231816abba584714c9e',
 		};
 
-		return calendarService.create(postBody, { payload: { userId: '0000d231816abba584714c9e' } }).then((result) => {
-			expect(result.length).to.be.above(0);
-		});
+		const result = await calendarService.create(postBody, { payload: { userId: '0000d231816abba584714c9e' } });
+		expect(result.length).to.be.above(0);
 	});
 
-	it('PUT /calendar', () => {
+	it('PUT /calendar', async () => {
 		const putBody = {
 			summary: 'ttt',
 			location: 'Paul-Gerhardt-Gymnasium',
@@ -76,15 +72,15 @@ describe('calendar service', function () {
 			scopeId: '0000d231816abba584714c9e',
 		};
 
-		return calendarService
-			.update('exampleId', putBody, { payload: { userId: '0000d231816abba584714c9e' } })
-			.then((result) => {
-				expect(result.length).to.be.above(0);
-			});
+		const result = await calendarService.update('exampleId', putBody, {
+			payload: { userId: '0000d231816abba584714c9e' },
+		});
+
+		expect(result.length).to.be.above(0);
 	});
 
-	it('DELETE /calendar', () =>
-		calendarService.remove('exampleId', { payload: { userId: '0000d231816abba584714c9e' } }).then((result) => {
-			expect(result).to.not.be.undefined;
-		}));
+	it('DELETE /calendar', async () => {
+		const result = await calendarService.remove('exampleId', { payload: { userId: '0000d231816abba584714c9e' } });
+		expect(result).to.not.be.undefined;
+	});
 });

--- a/test/services/courses/services/courseMembers.test.js
+++ b/test/services/courses/services/courseMembers.test.js
@@ -17,8 +17,8 @@ describe('course scope members service', () => {
 		server = app.listen(0);
 	});
 
-	after((done) => {
-		server.close(done);
+	after(async () => {
+		await server.close();
 	});
 
 	it('is properly registered', () => {
@@ -33,8 +33,7 @@ describe('course scope members service', () => {
 		let teacherParams;
 		let studentParams;
 
-		before(async function before() {
-			this.timeout(5000);
+		before(async () => {
 			teacher = await testObjects.createTestUser();
 			teacherParams = await generateRequestParamsFromUser(teacher);
 			student = await testObjects.createTestUser();
@@ -100,8 +99,7 @@ describe('course scope members service', () => {
 		const toId = (item) => item._id;
 		const toIdString = (item) => item._id.toString();
 
-		before(async function before() {
-			this.timeout(8000);
+		before(async () => {
 			teachers = [await testObjects.createTestUser(), await testObjects.createTestUser()];
 			substitutionTeachers = [await testObjects.createTestUser()];
 			students = [

--- a/test/services/datasources/datasourceRuns.test.js
+++ b/test/services/datasources/datasourceRuns.test.js
@@ -37,8 +37,7 @@ class MockSyncerWithData extends Syncer {
 	}
 }
 
-describe('datasourceRuns service', function test() {
-	this.timeout(10000);
+describe('datasourceRuns service', () => {
 	let app;
 	let datasourceRunsService;
 	let server;
@@ -56,10 +55,10 @@ describe('datasourceRuns service', function test() {
 		server = await app.listen(0);
 	});
 
-	after((done) => {
+	after(async () => {
 		mockery.deregisterAll();
 		mockery.disable();
-		server.close(done);
+		await server.close();
 	});
 
 	it('registered the datasourceRuns service', () => {


### PR DESCRIPTION
This PR removes this.timeout(number) from mocha tests which is not required, when async functions are called/awaited correctly. 
Most of the time now, the timeout or other bad styled tests just succeed without being correctly executed.
With Node 14.17 tests might log unhandled rejections, like   `message: 'unhandledRejection: jwt malformed\n' +` to alert wrong promise handling.

Further information: https://docs.hpi-schul-cloud.org/pages/viewpage.action?pageId=154188581