### PR TITLE
OPS-2574 - Removeing autodeployed branches for developers if branch deleted

### DIFF
--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -1,0 +1,22 @@
+---
+name: Clean Deployment
+
+on: delete
+
+jobs:
+  dispatch:
+    if: github.event.ref_type == 'branch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: hpi-schul-cloud/dof_app_deploy
+          event-type: dev-clean
+          client-payload: '{"branch": "${{ steps.extract_branch.outputs.branch}}" }'

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -11,12 +11,13 @@ jobs:
       - uses: actions/checkout@v2
       - name: Extract branch name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        id: extract_branch
+        run: |
+          git_ref_name='$(echo ${GITHUB_REF#refs/heads/})'
+          echo "git_ref_name=$git_ref_name" >> $GITHUB_ENV        
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: hpi-schul-cloud/dof_app_deploy
           event-type: dev-clean
-          client-payload: '{"branch": "${{ steps.extract_branch.outputs.branch}}" }'
+          client-payload: '{"branch": "${{ env.git_ref_name }}" }'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 - SC-8959 - Add messenger to deletion concept
 - SC-9157 - Add RabbitMQ connection to new mail service
 - SC-9157 - Improve config handling for RabbitMQ
+- OPS-2574 - Removeing autodeployed branches for developers if branch deleted
 
 ### Changed
 


### PR DESCRIPTION
# Description
Add an github action to clean out the deployment if a branch is delete.

## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/OPS-2574

## Changes
Add a new github action to remove deployments for deleted branches

## Datasecurity <sub><sup>details [on Confluence](https://docs.hpi-schul-cloud.org/x/2S3GBg)</sup></sub>


## Deployment

## New Repos, NPM pakages or vendor scripts


## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
