### PR TITLE
BC-37 - BC-54 - reduce resource consumption for deployed server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 ## Unreleased
 
 - BC-64 - enable e2e test execution for push event on main branch
+- BC-37 - BC-54 - reduce resource consumption for deployed server
 
 ## 26.9.1
 

--- a/ansible/roles/schulcloud-server/templates/api-worker-deployment.yml.j2
+++ b/ansible/roles/schulcloud-server/templates/api-worker-deployment.yml.j2
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: api-worker
 spec:
-  replicas: {{ API_REPLICAS|default("2", true) }}
+  replicas: {{ API_WORKER_REPLICAS|default("2", true) }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -63,8 +63,8 @@ spec:
           periodSeconds: 5
         resources:
           limits:
-            cpu: "1000m"
-            memory: "512Mi"
+            cpu: {{ API_CPU_LIMITS|default("2000m", true) }}
+            memory: {{ API_MEMORY_LIMITS|default("2Gi", true) }}
           requests:
-            cpu: "100m"
-            memory: "150Mi"
+            cpu: {{ API_CPU_REQUESTS|default("100m", true) }}
+            memory: {{ API_MEMORY_REQUESTS|default("150Mi", true) }}

--- a/ansible/roles/schulcloud-server/templates/deployment.yml.j2
+++ b/ansible/roles/schulcloud-server/templates/deployment.yml.j2
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: api
 spec:
-  replicas: {{ API_REPLICAS|default("2", true) }}
+  replicas: {{ API_REPLICAS|default("1", true) }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -64,8 +64,8 @@ spec:
           periodSeconds: 5
         resources:
           limits:
-            cpu: "2000m"
-            memory: "2Gi"
+            cpu: {{ API_CPU_LIMITS|default("2000m", true) }}
+            memory: {{ API_MEMORY_LIMITS|default("2Gi", true) }}
           requests:
-            cpu: "100m"
-            memory: "2Gi"
+            cpu: {{ API_CPU_REQUESTS|default("100m", true) }}
+            memory: {{ API_MEMORY_REQUESTS|default("150Mi", true) }}


### PR DESCRIPTION
# Description
Reduce resource consumption for deployed server.

## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/BC-37
https://ticketsystem.hpi-schul-cloud.org/browse/BC-54

## Changes
 Make CPU and memory resource consumption configurable.
 Set the default for memory to be between 150mb and 1gb.
 Set the default pod count to 1 pod

## Datasecurity <sub><sup>details [on Confluence](https://docs.hpi-schul-cloud.org/x/2S3GBg)</sup></sub>
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
