### PR TITLE
BC-247 - remove timestamp from LDAP search Query for sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 ### Removed
 
 - BC-262 - remove S3 lifecycle configuration code
+- BC-247 - remove timestamp from LDAP search Query for sync
 
 ## [26.10.3] - 2021-09-09
 

--- a/src/services/ldap/strategies/deltaSyncUtils.js
+++ b/src/services/ldap/strategies/deltaSyncUtils.js
@@ -10,20 +10,6 @@ const dateToLdapTimestamp = (date) => {
 };
 
 /**
- * Returns an LDAP filter to retrieve only recently updated entities (e.g. based on a
- * timestamp of a previous previous full sync). If the given attribute name does not
- * exist on the server, the resulting query gracefully falls back to all entities. The
- * logic is basically "search for all entities that either have a timestamp greater than
- * the given timestamp in the attribute with the given name, or don't have the attribute
- * at all".
- * @param {String} timestamp time of last modification, formatted as "YYYYMMDDHHmmssZ"
- * @param {String} attributeName optional attribute name to check
- */
-const getModifiedFilter = (timestamp, attributeName = 'modifyTimestamp') =>
-	// do unquel in combination with <= to get a > which is not supported by ldap
-	`(|(!(${attributeName}=*))(!(${attributeName}<=${timestamp})))`;
-
-/**
  * Returns an LDAP filter based on a given filter and a last change time. If lastChange is
  * undefined or does not match the correct format, the base filter is returned. Otherwise,
  * the base filter is combined with a filter for recently updated entities (i.e. updated
@@ -34,15 +20,10 @@ const getModifiedFilter = (timestamp, attributeName = 'modifyTimestamp') =>
  * @example
  *    filterForModifiedEntities(); // => ''
  *    filterForModifiedEntities('20201020000000Z', '(objectClass=person)');
- *    // => '(&(objectClass=person)(|(!(modifyTimestamp=*))(modifyTimestamp>=20201020000000Z)))'
+ *    // => '(objectClass=person)'
  */
 const filterForModifiedEntities = (school, existingFilter = '') => {
-	const lastChange = school && school.ldapLastSync;
-	if (!/\d{14}Z/.test(lastChange)) {
-		return existingFilter;
-	}
-	const filter = getModifiedFilter(lastChange);
-	return `(&${existingFilter}${filter})`;
+	return existingFilter;
 };
 
 module.exports = {

--- a/src/services/ldap/strategies/deltaSyncUtils.js
+++ b/src/services/ldap/strategies/deltaSyncUtils.js
@@ -1,15 +1,6 @@
 const moment = require('moment');
 
 /**
- * Convert date to LDAP timestamp format
- * @param date
- * @returns {string} formatted as "YYYYMMDDHHmmssZ"
- */
-const dateToLdapTimestamp = (date) => {
-	return `${moment(date).utc().format('YYYYMMDDHHmmss')}Z`;
-};
-
-/**
  * Returns an LDAP filter based on a given filter and a last change time. If lastChange is
  * undefined or does not match the correct format, the base filter is returned. Otherwise,
  * the base filter is combined with a filter for recently updated entities (i.e. updated
@@ -28,6 +19,4 @@ const filterForModifiedEntities = (school, existingFilter = '') => {
 
 module.exports = {
 	filterForModifiedEntities,
-	getModifiedFilter,
-	dateToLdapTimestamp,
 };

--- a/src/services/ldap/strategies/general.js
+++ b/src/services/ldap/strategies/general.js
@@ -145,7 +145,7 @@ class GeneralLDAPStrategy extends AbstractLDAPStrategy {
 
 		if (classPathAdditions !== '') {
 			const options = {
-				filter: filterForModifiedEntities(school, `${classAttributeNameMapping.description}=*`),
+				filter: filterForModifiedEntities(school, `(${classAttributeNameMapping.description}=*)`),
 				scope: 'sub',
 				attributes: [
 					classAttributeNameMapping.dn,

--- a/src/services/ldap/strategies/iserv.js
+++ b/src/services/ldap/strategies/iserv.js
@@ -30,7 +30,7 @@ class iServLDAPStrategy extends AbstractLDAPStrategy {
 	 */
 	getUsers(school) {
 		const options = {
-			filter: filterForModifiedEntities(school, 'objectClass=person'),
+			filter: filterForModifiedEntities(school, '(objectClass=person)'),
 			scope: 'sub',
 			attributes: ['givenName', 'sn', 'dn', 'uuid', 'uid', 'mail', 'objectClass', 'memberOf', 'modifyTimestamp'],
 		};

--- a/test/services/ldap/strategies/deltaSyncUtils.test.js
+++ b/test/services/ldap/strategies/deltaSyncUtils.test.js
@@ -3,28 +3,9 @@ const moment = require('moment');
 
 const {
 	filterForModifiedEntities,
-	getModifiedFilter,
-	dateToLdapTimestamp,
 } = require('../../../../src/services/ldap/strategies/deltaSyncUtils');
 
 describe('deltaSyncUtils', () => {
-	describe('#getModifiedFilter', () => {
-		it('returns expected filter based on timestamp', () => {
-			expect(getModifiedFilter('20201020000000Z')).to.equal(
-				'(|(!(modifyTimestamp=*))(!(modifyTimestamp<=20201020000000Z)))'
-			);
-			expect(getModifiedFilter('19890403203456Z')).to.equal(
-				'(|(!(modifyTimestamp=*))(!(modifyTimestamp<=19890403203456Z)))'
-			);
-		});
-
-		it('accepts an optional attribute name', () => {
-			expect(getModifiedFilter('19980219040216Z', 'updatedAt')).to.equal(
-				'(|(!(updatedAt=*))(!(updatedAt<=19980219040216Z)))'
-			);
-		});
-	});
-
 	describe('#filterForModifiedEntities', () => {
 		it('returns the base filter if no timestamp is given', () => {
 			expect(filterForModifiedEntities()).to.equal('');
@@ -37,21 +18,7 @@ describe('deltaSyncUtils', () => {
 
 		it('adds a timestamp based filter if correct format is used', () => {
 			const school = { ldapLastSync: '11111111111111Z' };
-			expect(filterForModifiedEntities(school, '(foo=bar)')).to.equal(
-				'(&(foo=bar)(|(!(modifyTimestamp=*))(!(modifyTimestamp<=11111111111111Z))))'
-			);
-		});
-	});
-
-	describe('#dateToLDAPTimestamp', () => {
-		it('should return date in format YYYYMMDDHHmmssZ', () => {
-			const date = new Date('2021-03-26T13:42:13.409Z');
-			expect(dateToLdapTimestamp(date)).to.equal('20210326134213Z');
-		});
-
-		it('should return correct date format for moment utc', () => {
-			const date = moment('2021-03-26T13:42:13.409Z').utc().toDate();
-			expect(dateToLdapTimestamp(date)).to.equal('20210326134213Z');
+			expect(filterForModifiedEntities(school, '(foo=bar)')).to.equal('(foo=bar)');
 		});
 	});
 });


### PR DESCRIPTION
# Description
remove timestamp from LDAP search Query for sync

## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/BC-247

## Changes
remove timestamp from LDAP search Query for sync

## Datasecurity <sub><sup>details [on Confluence](https://docs.hpi-schul-cloud.org/x/2S3GBg)</sup></sub>
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review

- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
