### PR TITLE
Fix configmap template to set the alert Featuer default as disable

### DIFF
--- a/ansible/roles/schulcloud-server/templates/configmap.yml.j2
+++ b/ansible/roles/schulcloud-server/templates/configmap.yml.j2
@@ -106,7 +106,7 @@ data:
 {% else %}
   ADMIN_TOGGLE_STUDENT_VISIBILITY: "enabled"
 {% endif %}
-  FEATURE_ALERTS_STATUS_ENABLED: "true"
+  FEATURE_ALERTS_STATUS_ENABLED: "{{ FEATURE_ALERTS_ENABLED|default("false") }}"
   ALERT_STATUS_URL: "{{ ALERT_STATUS_URL|default("https://status.hpi-schul-cloud.de", true) }}"
   ALERT_STATUS_API_URL: "{{ ALERT_STATUS_URL|default("https://status.hpi-schul-cloud.de", true) }}/api/v1"
   FEATURE_MORGAN_LOG_ENABLED: "false"


### PR DESCRIPTION
# Description
Fix configmap template to set the alert Featuer default as disable

## Links to Tickets or other pull requests
hpi-schul-cloud/schulcloud-client#2698

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity <sub><sup>details [on Confluence](https://docs.hpi-schul-cloud.org/x/2S3GBg)</sup></sub>
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
