### PR TITLE
Update pullapprove to the group of gernal

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -18,7 +18,7 @@ notifications:
       our Review-Guidelines https://docs.hpi-schul-cloud.org/display/SCDOK/Review-Guidelines
 
 groups:
-  sc-admins:
+  general:
     reviews:
       required: 1 # 1 approval from this group are required
     reviewers:


### PR DESCRIPTION
# Description
Next step on the new group plann for github.
Change the group to gerneral who is requeierd by pullaporve to approve pull request.

## Links to Tickets or other pull requests
hpi-schul-cloud/schulcloud-client#2700
hpi-schul-cloud/nuxt-client#1950
hpi-schul-cloud/end-to-end-tests#361

## Changes
Change the group to gerneral who is requeierd by pullaporve to approve pull request.

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
