### PR TITLE
OPS-3191 Updated schulcloud-server-init role to be togglable

### DIFF
--- a/ansible/roles/schulcloud-server-init/tasks/main.yml
+++ b/ansible/roles/schulcloud-server-init/tasks/main.yml
@@ -4,22 +4,65 @@
       kubeconfig: ~/.kube/config
       namespace: "{{ NAMESPACE }}"
       template: configmap_file_init_db.yml.j2
+    when: WITH_SCHULCLOUD_INIT
+
+  - name: Remove DB Init Configmap File
+    kubernetes.core.k8s:
+      kubeconfig: ~/.kube/config
+      namespace: "{{ NAMESPACE }}"
+      state: absent
+      apiVersion: v1
+      kind: ConfigMap
+      name: api-db-init-file
+    when: not WITH_SCHULCLOUD_INIT
 
   - name: Management Deployment
     kubernetes.core.k8s:
       kubeconfig: ~/.kube/config
       namespace: "{{ NAMESPACE }}"
       template: management-deployment.yml.j2
+    when: WITH_SCHULCLOUD_INIT
+
+  - name: Remove management Deployment
+    kubernetes.core.k8s:
+      kubeconfig: ~/.kube/config
+      namespace: "{{ NAMESPACE }}"
+      state: absent
+      apiVersion: apps/v1
+      kind: Deployment
+      name: management-deployment
+    when: not WITH_SCHULCLOUD_INIT
 
   - name: Management Service
     kubernetes.core.k8s:
       kubeconfig: ~/.kube/config
       namespace: "{{ NAMESPACE }}"
       template: management-svc.yml.j2
+    when: WITH_SCHULCLOUD_INIT
 
+  - name: Remove management Service
+    kubernetes.core.k8s:
+      kubeconfig: ~/.kube/config
+      namespace: "{{ NAMESPACE }}"
+      state: absent
+      apiVersion: v1
+      kind: Service
+      name: mgmt-svc
+    when: not WITH_SCHULCLOUD_INIT
 
   - name: DB Init Job
     kubernetes.core.k8s:
       kubeconfig: ~/.kube/config
       namespace: "{{ NAMESPACE }}"
       template: job_init_db.yml.j2
+    when: WITH_SCHULCLOUD_INIT
+
+  - name: Remove DB Init Job
+    kubernetes.core.k8s:
+      kubeconfig: ~/.kube/config
+      namespace: "{{ NAMESPACE }}"
+      state: absent
+      apiVersion: batch/v1
+      kind: Job
+      name: api-db-init-job
+    when: not WITH_SCHULCLOUD_INIT


### PR DESCRIPTION
# Description
Updated the schulcloud-server-init role to be togglable with the WITH_SCHULCLOUD_INIT variable

## Links to Tickets or other pull requests


## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Deployment
Needs  the WITH_SCHULCLOUD_INIT variable from https://github.com/hpi-schul-cloud/dof_app_deploy/pull/176

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
