### PR TITLE
EW-212 Fix typos and extended documentation.

### DIFF
--- a/apps/server/doc/keycloak.md
+++ b/apps/server/doc/keycloak.md
@@ -7,7 +7,7 @@
 ## Docker
 
 To run Keycloak locally for development purpose use the following Bash or PowerShell command. You can log into Keycloak
-here http://localhost:8080. If you don't want to block your terminal, you can add the `-d` option to start the container
+here <http://localhost:8080>. If you don't want to block your terminal, you can add the `-d` option to start the container
 in the background. Execute these commands in the repository root or the data seeding will fail, and you can not log into
 Keycloak with any user.
 
@@ -52,7 +52,7 @@ and testing. In the table below you can see the username and password combinatio
 | Username       | Password       | Description                                              |
 | :------------- | :------------- | :------------------------------------------------------- |
 | keycloak       | keycloak       | The overall Keycloak administrator with all permissions. |
-| dbildungscloud | dbildungscloud | The dBildungscloud realm specific administrator.         |
+| dbildungscloud | dBildungscloud | The dBildungscloud realm specific administrator.         |
 
 ## Updating Seed Data
 
@@ -65,3 +65,8 @@ and testing. In the table below you can see the username and password combinatio
 > IMPORTANT: During the export process there will be some errors, that's because the export process will be done on the
 > same port as the Keycloak server. This leads to Keycloak failing to start the server in import/export mode. Due to the
 > transition from WildFly to Quarkus as application server there is currently no documentation on this topic.
+
+In order to re-apply the seeding data for a running keycloak container, you may run following commands (to be executed in the repository root):
+
+1. `docker cp ./backup/keycloak keycloak:/tmp/realms`
+2. `docker exec keycloak /opt/keycloak/bin/kc.sh import --dir /tmp/realms`

--- a/backup/keycloak/dBildungscloud-realm.json
+++ b/backup/keycloak/dBildungscloud-realm.json
@@ -1,5 +1,5 @@
 {
-  "id" : "dBildunscloud",
+  "id" : "dBildungscloud",
   "realm" : "dBildungscloud",
   "notBefore" : 0,
   "defaultSignatureAlgorithm" : "RS256",
@@ -50,11 +50,11 @@
       "description" : "${role_uma_authorization}",
       "composite" : false,
       "clientRole" : false,
-      "containerId" : "dBildunscloud",
+      "containerId" : "dBildungscloud",
       "attributes" : { }
     }, {
       "id" : "1a4f9536-2180-41b1-9815-08d01d456270",
-      "name" : "default-roles-dbildunscloud",
+      "name" : "default-roles-dbildungscloud",
       "description" : "${role_default-roles}",
       "composite" : true,
       "composites" : {
@@ -64,7 +64,7 @@
         }
       },
       "clientRole" : false,
-      "containerId" : "dBildunscloud",
+      "containerId" : "dBildungscloud",
       "attributes" : { }
     }, {
       "id" : "2093bbce-2c25-4c20-bdca-f35d7682cb5b",
@@ -72,7 +72,7 @@
       "description" : "${role_offline-access}",
       "composite" : false,
       "clientRole" : false,
-      "containerId" : "dBildunscloud",
+      "containerId" : "dBildungscloud",
       "attributes" : { }
     } ],
     "client" : {
@@ -344,11 +344,11 @@
   } ],
   "defaultRole" : {
     "id" : "1a4f9536-2180-41b1-9815-08d01d456270",
-    "name" : "default-roles-dbildunscloud",
+    "name" : "default-roles-dbildungscloud",
     "description" : "${role_default-roles}",
     "composite" : true,
     "clientRole" : false,
-    "containerId" : "dBildunscloud"
+    "containerId" : "dBildungscloud"
   },
   "requiredCredentials" : [ "password" ],
   "otpPolicyType" : "totp",
@@ -421,12 +421,12 @@
     "clientId" : "account-console",
     "name" : "${client_account-console}",
     "rootUrl" : "${authBaseUrl}",
-    "baseUrl" : "/realms/dBildunscloud/account/",
+    "baseUrl" : "/realms/dBildungscloud/account/",
     "surrogateAuthRequired" : false,
     "enabled" : true,
     "alwaysDisplayInConsole" : false,
     "clientAuthenticatorType" : "client-secret",
-    "redirectUris" : [ "/realms/dBildunscloud/account/*" ],
+    "redirectUris" : [ "/realms/dBildungscloud/account/*" ],
     "webOrigins" : [ ],
     "notBefore" : 0,
     "bearerOnly" : false,

--- a/backup/keycloak/master-realm.json
+++ b/backup/keycloak/master-realm.json
@@ -660,7 +660,7 @@
   }, {
     "id" : "3b4d9f3b-92b0-4854-9f9e-9788233bd0c4",
     "clientId" : "dBildungscloud-realm",
-    "name" : "dBildunscloud Realm",
+    "name" : "dBildungscloud Realm",
     "surrogateAuthRequired" : false,
     "enabled" : true,
     "alwaysDisplayInConsole" : false,


### PR DESCRIPTION
# Description
Fixed a typo in the Keycloak configuration (dBildun_g_scloud, 'g' was missing). Also extended and fixed a typo in the Keycloak.MD.

## Links to Tickets or other pull requests

https://ticketsystem.dbildungscloud.de/browse/EW-212

## Changes

See description

## Datasecurity <sub><sup>details [on Confluence](https://docs.hpi-schul-cloud.org/x/2S3GBg)</sup></sub>

Does not apply.

## Deployment

Does not apply.

## New Repos, NPM pakages or vendor scripts

Does not apply.

## Approval for review

- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
