### PR TITLE
Bump winston from 3.5.1 to 3.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -112,7 +112,7 @@
 				"universal-analytics": "^0.5.1",
 				"urlsafe-base64": "^1.0.0",
 				"uuid": "^8.3.0",
-				"winston": "^3.2.0",
+				"winston": "^3.7.2",
 				"xml2js-es6-promise": "^1.1.1"
 			},
 			"devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
 				"aws-sdk": "^2.1041.0",
 				"axios": "^0.25.0",
 				"bbb-promise": "^1.2.0",
-				"bcryptjs": "latest",
+				"bcryptjs": "*",
 				"body-parser": "^1.15.2",
 				"bson": "^4.6.0",
 				"busboy": "^1.4.0",
@@ -3390,6 +3390,14 @@
 			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
+		},
+		"node_modules/@colors/colors": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+			"engines": {
+				"node": ">=0.1.90"
+			}
 		},
 		"node_modules/@compodoc/compodoc": {
 			"version": "1.1.18",
@@ -17593,21 +17601,16 @@
 			}
 		},
 		"node_modules/logform": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/logform/-/logform-2.3.2.tgz",
-			"integrity": "sha512-V6JiPThZzTsbVRspNO6TmHkR99oqYTs8fivMBYQkjZj6rxW92KxtDCPE6IkAk1DNBnYKNkjm4jYBm6JDUcyhOA==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/logform/-/logform-2.4.0.tgz",
+			"integrity": "sha512-CPSJw4ftjf517EhXZGGvTHHkYobo7ZCc0kvwUoOYcjfR2UVrI66RHj8MCrfAdEitdmFqbu2BYdYs8FHHZSb6iw==",
 			"dependencies": {
-				"colors": "1.4.0",
+				"@colors/colors": "1.5.0",
 				"fecha": "^4.2.0",
 				"ms": "^2.1.1",
-				"safe-stable-stringify": "^1.1.0",
+				"safe-stable-stringify": "^2.3.1",
 				"triple-beam": "^1.3.0"
 			}
-		},
-		"node_modules/logform/node_modules/safe-stable-stringify": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
-			"integrity": "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw=="
 		},
 		"node_modules/loglevel": {
 			"version": "1.8.0",
@@ -26662,23 +26665,23 @@
 			}
 		},
 		"node_modules/winston": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-3.5.1.tgz",
-			"integrity": "sha512-tbRtVy+vsSSCLcZq/8nXZaOie/S2tPXPFt4be/Q3vI/WtYwm7rrwidxVw2GRa38FIXcJ1kUM6MOZ9Jmnk3F3UA==",
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-3.7.2.tgz",
+			"integrity": "sha512-QziIqtojHBoyzUOdQvQiar1DH0Xp9nF1A1y7NVy2DGEsz82SBDtOalS0ulTRGVT14xPX3WRWkCsdcJKqNflKng==",
 			"dependencies": {
 				"@dabh/diagnostics": "^2.0.2",
 				"async": "^3.2.3",
 				"is-stream": "^2.0.0",
-				"logform": "^2.3.2",
+				"logform": "^2.4.0",
 				"one-time": "^1.0.0",
 				"readable-stream": "^3.4.0",
 				"safe-stable-stringify": "^2.3.1",
 				"stack-trace": "0.0.x",
 				"triple-beam": "^1.3.0",
-				"winston-transport": "^4.4.2"
+				"winston-transport": "^4.5.0"
 			},
 			"engines": {
-				"node": ">= 6.4.0"
+				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/winston-transport": {
@@ -29578,6 +29581,11 @@
 			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
+		},
+		"@colors/colors": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
 		},
 		"@compodoc/compodoc": {
 			"version": "1.1.18",
@@ -40517,22 +40525,15 @@
 			}
 		},
 		"logform": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/logform/-/logform-2.3.2.tgz",
-			"integrity": "sha512-V6JiPThZzTsbVRspNO6TmHkR99oqYTs8fivMBYQkjZj6rxW92KxtDCPE6IkAk1DNBnYKNkjm4jYBm6JDUcyhOA==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/logform/-/logform-2.4.0.tgz",
+			"integrity": "sha512-CPSJw4ftjf517EhXZGGvTHHkYobo7ZCc0kvwUoOYcjfR2UVrI66RHj8MCrfAdEitdmFqbu2BYdYs8FHHZSb6iw==",
 			"requires": {
-				"colors": "1.4.0",
+				"@colors/colors": "1.5.0",
 				"fecha": "^4.2.0",
 				"ms": "^2.1.1",
-				"safe-stable-stringify": "^1.1.0",
+				"safe-stable-stringify": "^2.3.1",
 				"triple-beam": "^1.3.0"
-			},
-			"dependencies": {
-				"safe-stable-stringify": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
-					"integrity": "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw=="
-				}
 			}
 		},
 		"loglevel": {
@@ -47599,20 +47600,20 @@
 			}
 		},
 		"winston": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-3.5.1.tgz",
-			"integrity": "sha512-tbRtVy+vsSSCLcZq/8nXZaOie/S2tPXPFt4be/Q3vI/WtYwm7rrwidxVw2GRa38FIXcJ1kUM6MOZ9Jmnk3F3UA==",
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-3.7.2.tgz",
+			"integrity": "sha512-QziIqtojHBoyzUOdQvQiar1DH0Xp9nF1A1y7NVy2DGEsz82SBDtOalS0ulTRGVT14xPX3WRWkCsdcJKqNflKng==",
 			"requires": {
 				"@dabh/diagnostics": "^2.0.2",
 				"async": "^3.2.3",
 				"is-stream": "^2.0.0",
-				"logform": "^2.3.2",
+				"logform": "^2.4.0",
 				"one-time": "^1.0.0",
 				"readable-stream": "^3.4.0",
 				"safe-stable-stringify": "^2.3.1",
 				"stack-trace": "0.0.x",
 				"triple-beam": "^1.3.0",
-				"winston-transport": "^4.4.2"
+				"winston-transport": "^4.5.0"
 			},
 			"dependencies": {
 				"readable-stream": {

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
 		"universal-analytics": "^0.5.1",
 		"urlsafe-base64": "^1.0.0",
 		"uuid": "^8.3.0",
-		"winston": "^3.2.0",
+		"winston": "^3.7.2",
 		"xml2js-es6-promise": "^1.1.1"
 	},
 	"devDependencies": {


### PR DESCRIPTION
# Description
Bumps [winston](https://github.com/winstonjs/winston) from 3.5.1 to 3.7.2.
- [Release notes](https://github.com/winstonjs/winston/releases)
- [Changelog](https://github.com/winstonjs/winston/blob/master/CHANGELOG.md)
- [Commits](https://github.com/winstonjs/winston/commits)

---
updated-dependencies:
- dependency-name: winston
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

## Links to Tickets or other pull requests
#3415 

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity <sub><sup>details [on Confluence](https://docs.hpi-schul-cloud.org/x/2S3GBg)</sup></sub>
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
