### PR TITLE
BC-1436 - add logging for Users and Classes errors for the ldap sync

### DIFF
--- a/src/services/sync/strategies/LDAPSyncer.js
+++ b/src/services/sync/strategies/LDAPSyncer.js
@@ -55,17 +55,27 @@ class LDAPSyncer extends Syncer {
 	}
 
 	async processLdapUsers(school) {
-		syncLogger.info(`Getting users for school ${school.name}`, { syncId: this.syncId });
-		const ldapUsers = await this.ldapService.getUsers(this.system.ldapConfig, school);
-		this.stats.users += ldapUsers.length;
-		await this.sendLdapUsers(ldapUsers, school.ldapSchoolIdentifier);
+		try {
+			syncLogger.info(`Getting users for school ${school.name}`, { syncId: this.syncId });
+			const ldapUsers = await this.ldapService.getUsers(this.system.ldapConfig, school);
+			this.stats.users += ldapUsers.length;
+			await this.sendLdapUsers(ldapUsers, school.ldapSchoolIdentifier);
+		} catch (err) {
+			this.logError('Error while syncing', { error: err, syncId: this.syncId });
+			this.stats.errors.push(err);
+		}
 	}
 
 	async processLdapClasses(school) {
-		syncLogger.info(`Getting classes for school ${school.name}`, { syncId: this.syncId });
-		const ldapClasses = await this.ldapService.getClasses(this.system.ldapConfig, school);
-		this.stats.classes += ldapClasses.length;
-		await this.sendLdapClasses(ldapClasses, school);
+		try {
+			syncLogger.info(`Getting classes for school ${school.name}`, { syncId: this.syncId });
+			const ldapClasses = await this.ldapService.getClasses(this.system.ldapConfig, school);
+			this.stats.classes += ldapClasses.length;
+			await this.sendLdapClasses(ldapClasses, school);
+		} catch (err) {
+			this.logError('Error while syncing', { error: err, syncId: this.syncId });
+			this.stats.errors.push(err);
+		}
 	}
 
 	async sendLdapSchools(ldapSchools, currentYear, federalState) {

--- a/src/services/sync/strategies/LDAPSyncer.js
+++ b/src/services/sync/strategies/LDAPSyncer.js
@@ -61,7 +61,7 @@ class LDAPSyncer extends Syncer {
 			this.stats.users += ldapUsers.length;
 			await this.sendLdapUsers(ldapUsers, school.ldapSchoolIdentifier);
 		} catch (err) {
-			this.logError('Error while syncing', { error: err, syncId: this.syncId });
+			syncLogger.error('Error while syncing process Ldap Users', { error: err, syncId: this.syncId });
 			this.stats.errors.push(err);
 		}
 	}
@@ -73,7 +73,7 @@ class LDAPSyncer extends Syncer {
 			this.stats.classes += ldapClasses.length;
 			await this.sendLdapClasses(ldapClasses, school);
 		} catch (err) {
-			this.logError('Error while syncing', { error: err, syncId: this.syncId });
+			syncLogger.error('Error while syncing process Ldap Classes', { error: err, syncId: this.syncId });
 			this.stats.errors.push(err);
 		}
 	}


### PR DESCRIPTION
# Description
Make the LDAP Sync more robust by adding logging to users and classes.
If for one school of an LDAP System with many schools in it, the user don't sync, then only the users from this one school are partially synced.
The same is for classes.

## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/BC-1436

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity <sub><sup>details [on Confluence](https://docs.dbildungscloud.de/x/2S3GBg)</sup></sub>
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.dbildungscloud.de/pages/viewpage.action?pageId=92831762)
