### PR TITLE
Ew 288 Full idempotence for "setup:idm:configure"

### DIFF
--- a/apps/server/src/shared/domain/entity/system.entity.ts
+++ b/apps/server/src/shared/domain/entity/system.entity.ts
@@ -79,7 +79,7 @@ export class System extends BaseEntityWithTimestamps {
 	@Property({ nullable: true })
 	url?: string;
 
-	@Property({ nullable: true, unique: true })
+	@Property({ nullable: true })
 	alias?: string;
 
 	@Property({ nullable: true })

--- a/apps/server/src/shared/infra/identity-management/keycloak/service/keycloak-configuration.service.spec.ts
+++ b/apps/server/src/shared/infra/identity-management/keycloak/service/keycloak-configuration.service.spec.ts
@@ -225,7 +225,7 @@ describe('configureIdentityProviders', () => {
 
 	describe('configureBrokerFlows', () => {
 		beforeAll(() => {
-			kcApiRealmsMock.makeRequest.mockImplementation(() => async () => Promise.resolve([]));
+			kcApiRealmsMock.makeRequest.mockImplementation(() => async () => Promise.resolve([{ id: 'id' }]));
 		});
 
 		beforeEach(() => {
@@ -270,7 +270,7 @@ describe('configureIdentityProviders', () => {
 				})
 			);
 		});
-		it('should delete and create flow', async () => {
+		it('should skip flow creation', async () => {
 			kcApiRealmsMock.makeRequest.mockImplementation(
 				() => async () => Promise.resolve([{ alias: 'Direct Broker Flow', id: 'id' }])
 			);
@@ -278,44 +278,30 @@ describe('configureIdentityProviders', () => {
 			await expect(service.configureBrokerFlows()).resolves.not.toThrow();
 			expect(kcApiRealmsMock.makeRequest).toBeCalledWith(
 				expect.objectContaining({
-					method: 'POST',
-					path: '/{realmName}/authentication/flows',
-					urlParamKeys: ['realmName'],
-				})
-			);
-			expect(kcApiRealmsMock.makeRequest).toBeCalledWith(
-				expect.objectContaining({
 					method: 'GET',
 					path: '/{realmName}/authentication/flows',
 					urlParamKeys: ['realmName'],
 				})
 			);
-			expect(kcApiRealmsMock.makeRequest).toBeCalledWith(
+			expect(kcApiRealmsMock.makeRequest).not.toBeCalledWith(
 				expect.objectContaining({
 					method: 'GET',
 					path: '/{realmName}/authentication/flows/{flowAlias}/executions',
 					urlParamKeys: ['realmName', 'flowAlias'],
 				})
 			);
-			expect(kcApiRealmsMock.makeRequest).toBeCalledWith(
+			expect(kcApiRealmsMock.makeRequest).not.toBeCalledWith(
 				expect.objectContaining({
 					method: 'POST',
 					path: '/{realmName}/authentication/flows/{flowAlias}/executions/execution',
 					urlParamKeys: ['realmName', 'flowAlias'],
 				})
 			);
-			expect(kcApiRealmsMock.makeRequest).toBeCalledWith(
+			expect(kcApiRealmsMock.makeRequest).not.toBeCalledWith(
 				expect.objectContaining({
 					method: 'PUT',
 					path: '/{realmName}/authentication/flows/{flowAlias}/executions',
 					urlParamKeys: ['realmName', 'flowAlias'],
-				})
-			);
-			expect(kcApiRealmsMock.makeRequest).toBeCalledWith(
-				expect.objectContaining({
-					method: 'DELETE',
-					path: '/{realmName}/authentication/flows/{id}',
-					urlParamKeys: ['realmName', 'id'],
 				})
 			);
 		});


### PR DESCRIPTION
# Description
Ensures that `npm run setup:idm:configure` is idempotent and removed database constraint on `System.alias`.

## Links to Tickets or other pull requests
- https://ticketsystem.dbildungscloud.de/browse/EW-288

## Changes
See description and Jira ticket.

## Datasecurity
Does not apply.

## Deployment
Does not apply.

## New Repos, NPM pakages or vendor scripts
Does not apply.

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
