### PR TITLE
BC-2630 Increasing nest_tests_cov timeout from 12 to 15 minutes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         run: npm run feathers:test
   nest_tests_cov:
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 15
     services:
       rabbitmq:
         image: rabbitmq:3


### PR DESCRIPTION
# Description
Increasing the timeout for the nest_tests_cov to 15 minutes to prevent the canceling of the job.

## Links to Tickets or other pull requests
- <https://ticketsystem.dbildungscloud.de/browse/BC-2630>
- <https://docs.dbildungscloud.de/x/8wCvDQ>

## Changes
See description and Jira ticket.

## Datasecurity
Does not apply.

## Deployment
Does not apply.

## New Repos, NPM pakages or vendor scripts
Does not apply.

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
