### PR TITLE
N21-481 Fix missing endpoint auth method

### DIFF
--- a/apps/server/src/modules/tool/controller/dto/response/oauth2-tool-config.response.ts
+++ b/apps/server/src/modules/tool/controller/dto/response/oauth2-tool-config.response.ts
@@ -36,5 +36,6 @@ export class Oauth2ToolConfigResponse extends ExternalToolConfigResponse {
 		this.frontchannelLogoutUri = props.frontchannelLogoutUri;
 		this.scope = props.scope;
 		this.redirectUris = props.redirectUris;
+		this.tokenEndpointAuthMethod = props.tokenEndpointAuthMethod;
 	}
 }

--- a/apps/server/src/modules/tool/controller/mapper/external-tool-response.mapper.spec.ts
+++ b/apps/server/src/modules/tool/controller/mapper/external-tool-response.mapper.spec.ts
@@ -14,6 +14,7 @@ import {
 	CustomParameterTypeParams,
 	LtiMessageType,
 	LtiPrivacyPermission,
+	TokenEndpointAuthMethod,
 	ToolConfigType,
 } from '../../interface';
 import {
@@ -119,6 +120,11 @@ describe('ExternalToolResponseMapper', () => {
 					skipConsent: false,
 					type: ToolConfigType.OAUTH2,
 					baseUrl: 'mockUrl',
+					tokenEndpointAuthMethod: TokenEndpointAuthMethod.CLIENT_SECRET_POST,
+					scope: 'test',
+					clientSecret: 'secret',
+					frontchannelLogoutUri: 'http://logout',
+					redirectUris: ['redirectUri'],
 				});
 
 				const oauth2ToolConfigResponse: Oauth2ToolConfigResponse = new Oauth2ToolConfigResponse({
@@ -126,6 +132,10 @@ describe('ExternalToolResponseMapper', () => {
 					skipConsent: false,
 					type: ToolConfigType.OAUTH2,
 					baseUrl: 'mockUrl',
+					tokenEndpointAuthMethod: TokenEndpointAuthMethod.CLIENT_SECRET_POST,
+					scope: 'test',
+					frontchannelLogoutUri: 'http://logout',
+					redirectUris: ['redirectUri'],
 				});
 
 				return {
@@ -133,6 +143,7 @@ describe('ExternalToolResponseMapper', () => {
 					oauth2ToolConfigDO,
 				};
 			};
+
 			it('should map a oauth2 tool do to a oauth2 tool response', () => {
 				const { oauth2ToolConfigDO, oauth2ToolConfigResponse } = oauthSetup();
 				const { externalToolDO, externalToolResponse } = setup();


### PR DESCRIPTION
# Description
This extended mapping fixes the missing endpoint auth method in shd for ctl tools.
<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the begining of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/N21-481
<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
