### PR TITLE
BC 2776 Add multi line logging for ldap sync jobs

### DIFF
--- a/ansible/roles/schulcloud-server-ldapsync/templates/api-ldap-sync-full-cronjob.yml.j2
+++ b/ansible/roles/schulcloud-server-ldapsync/templates/api-ldap-sync-full-cronjob.yml.j2
@@ -22,5 +22,5 @@ spec:
             - secretRef:
                 name: api-secret
             command: ['/bin/sh','-c']
-            args: ['curl --max-time {{ SERVER_LDAP_SYNC_FULL_CRONJOB_TIMEOUT|default("39600", true) }} -H "X-API-Key: $SYNC_API_KEY" "http://{{ API_LDAP_SYNC_SVC|default("api-ldapsync-svc", true) }}:3030/api/v1/sync?target=ldap&forceFullSync=true" | jq "."']
+            args: ['curl --max-time {{ SERVER_LDAP_SYNC_FULL_CRONJOB_TIMEOUT|default("39600", true) }} -H "X-API-Key: $SYNC_API_KEY" "http://{{ API_LDAP_SYNC_SVC|default("api-ldapsync-svc", true) }}:3030/api/v1/sync?target=ldap&forceFullSync=true" | python -m json.tool']
           restartPolicy: OnFailure

--- a/ansible/roles/schulcloud-server-ldapsync/templates/api-ldap-sync-full-cronjob.yml.j2
+++ b/ansible/roles/schulcloud-server-ldapsync/templates/api-ldap-sync-full-cronjob.yml.j2
@@ -17,10 +17,10 @@ spec:
         spec:
           containers:
           - name: api-ldapsync-cronjob
-            image: curlimages/curl:7.86.0
+            image: schulcloud/infra-tools:latest
             envFrom:
             - secretRef:
                 name: api-secret
             command: ['/bin/sh','-c']
-            args: ['curl --max-time {{ SERVER_LDAP_SYNC_FULL_CRONJOB_TIMEOUT|default("39600", true) }} -H "X-API-Key: $SYNC_API_KEY" "http://{{ API_LDAP_SYNC_SVC|default("api-ldapsync-svc", true) }}:3030/api/v1/sync?target=ldap&forceFullSync=true"']
+            args: ['curl --max-time {{ SERVER_LDAP_SYNC_FULL_CRONJOB_TIMEOUT|default("39600", true) }} -H "X-API-Key: $SYNC_API_KEY" "http://{{ API_LDAP_SYNC_SVC|default("api-ldapsync-svc", true) }}:3030/api/v1/sync?target=ldap&forceFullSync=true" | jq "."']
           restartPolicy: OnFailure

--- a/ansible/roles/schulcloud-server-ldapsync/templates/api-ldap-sync-full-cronjob.yml.j2
+++ b/ansible/roles/schulcloud-server-ldapsync/templates/api-ldap-sync-full-cronjob.yml.j2
@@ -22,5 +22,5 @@ spec:
             - secretRef:
                 name: api-secret
             command: ['/bin/sh','-c']
-            args: ['curl --max-time {{ SERVER_LDAP_SYNC_FULL_CRONJOB_TIMEOUT|default("39600", true) }} -H "X-API-Key: $SYNC_API_KEY" "http://{{ API_LDAP_SYNC_SVC|default("api-ldapsync-svc", true) }}:3030/api/v1/sync?target=ldap&forceFullSync=true" | python -m json.tool']
+            args: ['curl --max-time {{ SERVER_LDAP_SYNC_FULL_CRONJOB_TIMEOUT|default("39600", true) }} -H "X-API-Key: $SYNC_API_KEY" "http://{{ API_LDAP_SYNC_SVC|default("api-ldapsync-svc", true) }}:3030/api/v1/sync?target=ldap&forceFullSync=true" | python3 -m json.tool']
           restartPolicy: OnFailure

--- a/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-base-cronjob.yml.j2
+++ b/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-base-cronjob.yml.j2
@@ -21,5 +21,5 @@ spec:
             - secretRef:
                 name: api-secret
             command: ['/bin/sh','-c']
-            args: ['curl -H "X-API-Key: $SYNC_API_KEY" "http://{{ API_TSP_SYNC_SVC|default("api-tsp-sync-svc", true) }}:3030/api/v1/sync?target=tsp-base" | python -m json.tool']
+            args: ['curl -H "X-API-Key: $SYNC_API_KEY" "http://{{ API_TSP_SYNC_SVC|default("api-tsp-sync-svc", true) }}:3030/api/v1/sync?target=tsp-base" | python3 -m json.tool']
           restartPolicy: OnFailure

--- a/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-base-cronjob.yml.j2
+++ b/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-base-cronjob.yml.j2
@@ -21,5 +21,5 @@ spec:
             - secretRef:
                 name: api-secret
             command: ['/bin/sh','-c']
-            args: ['curl -H "X-API-Key: $SYNC_API_KEY" "http://{{ API_TSP_SYNC_SVC|default("api-tsp-sync-svc", true) }}:3030/api/v1/sync?target=tsp-base" | jq "."']
+            args: ['curl -H "X-API-Key: $SYNC_API_KEY" "http://{{ API_TSP_SYNC_SVC|default("api-tsp-sync-svc", true) }}:3030/api/v1/sync?target=tsp-base" | python -m json.tool']
           restartPolicy: OnFailure

--- a/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-base-cronjob.yml.j2
+++ b/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-base-cronjob.yml.j2
@@ -16,10 +16,10 @@ spec:
         spec:
           containers:
           - name: api-tsp-sync-base-cronjob
-            image: curlimages/curl:7.86.0
+            image: schulcloud/infra-tools:latest
             envFrom:
             - secretRef:
                 name: api-secret
             command: ['/bin/sh','-c']
-            args: ['curl -H "X-API-Key: $SYNC_API_KEY" "http://{{ API_TSP_SYNC_SVC|default("api-tsp-sync-svc", true) }}:3030/api/v1/sync?target=tsp-base"']
+            args: ['curl -H "X-API-Key: $SYNC_API_KEY" "http://{{ API_TSP_SYNC_SVC|default("api-tsp-sync-svc", true) }}:3030/api/v1/sync?target=tsp-base" | jq "."']
           restartPolicy: OnFailure

--- a/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-school-cronjob.yml.j2
+++ b/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-school-cronjob.yml.j2
@@ -21,5 +21,5 @@ spec:
             - secretRef:
                 name: api-secret
             command: ['/bin/sh','-c']
-            args: ['curl -H "X-API-Key: $SYNC_API_KEY" "http://{{ API_TSP_SYNC_SVC|default("api-tsp-sync-svc", true) }}:3030/api/v1/sync?target=tsp-school" | jq "."']
+            args: ['curl -H "X-API-Key: $SYNC_API_KEY" "http://{{ API_TSP_SYNC_SVC|default("api-tsp-sync-svc", true) }}:3030/api/v1/sync?target=tsp-school" | python -m json.tool']
           restartPolicy: OnFailure

--- a/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-school-cronjob.yml.j2
+++ b/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-school-cronjob.yml.j2
@@ -21,5 +21,5 @@ spec:
             - secretRef:
                 name: api-secret
             command: ['/bin/sh','-c']
-            args: ['curl -H "X-API-Key: $SYNC_API_KEY" "http://{{ API_TSP_SYNC_SVC|default("api-tsp-sync-svc", true) }}:3030/api/v1/sync?target=tsp-school" | python -m json.tool']
+            args: ['curl -H "X-API-Key: $SYNC_API_KEY" "http://{{ API_TSP_SYNC_SVC|default("api-tsp-sync-svc", true) }}:3030/api/v1/sync?target=tsp-school" | python3 -m json.tool']
           restartPolicy: OnFailure

--- a/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-school-cronjob.yml.j2
+++ b/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-school-cronjob.yml.j2
@@ -16,10 +16,10 @@ spec:
         spec:
           containers:
           - name: api-tsp-sync-school-cronjob
-            image: curlimages/curl:7.86.0
+            image: schulcloud/infra-tools:latest
             envFrom:
             - secretRef:
                 name: api-secret
             command: ['/bin/sh','-c']
-            args: ['curl -H "X-API-Key: $SYNC_API_KEY" "http://{{ API_TSP_SYNC_SVC|default("api-tsp-sync-svc", true) }}:3030/api/v1/sync?target=tsp-school"']
+            args: ['curl -H "X-API-Key: $SYNC_API_KEY" "http://{{ API_TSP_SYNC_SVC|default("api-tsp-sync-svc", true) }}:3030/api/v1/sync?target=tsp-school" | jq "."']
           restartPolicy: OnFailure


### PR DESCRIPTION
# Description
This release will add multi line logging for ldap sync jobs to prevent logs to be cut off.
 
## Links to Tickets or other pull requests
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/3775
- https://ticketsystem.dbildungscloud.de/browse/BC-2776

## Changes
- use infra-tools image instead of curl for sync cron jobs
- use jq to format the output

## Datasecurity

## Deployment

## New Repos, NPM pakages or vendor scripts

## Screenshots of UI changes
![2776](https://user-images.githubusercontent.com/118526182/207569473-b022c7ff-ef24-4733-8e81-e283575d2f0a.jpg)


## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
