### PR TITLE
BC-1530-Added-permission-for-student

### DIFF
--- a/backup/setup/migrations.json
+++ b/backup/setup/migrations.json
@@ -119,5 +119,16 @@
 			"$date": "2023-01-12T18:24:50.878Z"
 		},
 		"__v": 0
+	},
+	{
+		"_id": {
+			"$oid": "63e39c6567305f4774cb0d7f"
+		},
+		"state": "up",
+		"name": "AddCreateToolPermissionForUser",
+		"createdAt": {
+			"$date": "2023-02-08T12:44:11.087Z"
+		},
+		"__v": 0
 	}
 ]

--- a/backup/setup/roles.json
+++ b/backup/setup/roles.json
@@ -257,7 +257,7 @@
 		},
 		"name": "student",
 		"updatedAt": {
-			"$date": "2022-05-20T13:33:18.077Z"
+			"$date": "2023-02-08T12:46:58.680Z"
 		},
 		"createdAt": {
 			"$date": "2017-01-01T00:06:37.148Z"
@@ -271,7 +271,8 @@
 			"TASK_DASHBOARD_VIEW_V3",
 			"JOIN_MEETING",
 			"TEAM_CREATE",
-			"TEAM_EDIT"
+			"TEAM_EDIT",
+			"TOOL_CREATE"
 		],
 		"__v": 0
 	},

--- a/migrations/1675860251087-AddCreateToolPermissionForUser.js
+++ b/migrations/1675860251087-AddCreateToolPermissionForUser.js
@@ -1,0 +1,57 @@
+const mongoose = require('mongoose');
+// eslint-disable-next-line no-unused-vars
+const { alert, error } = require('../src/logger');
+
+const { connect, close } = require('../src/utils/database');
+
+// use your own name for your model, otherwise other migrations may fail.
+// The third parameter is the actually relevent one for what collection to write to.
+const Roles = mongoose.model(
+	'role_202304011543',
+	new mongoose.Schema(
+		{
+			name: { type: String, required: true },
+			permissions: [{ type: String }],
+		},
+		{
+			timestamps: true,
+		}
+	),
+	'roles'
+);
+
+module.exports = {
+	up: async function up() {
+		await connect();
+
+		await Roles.updateOne(
+			{ name: 'student' },
+			{
+				$addToSet: {
+					permissions: {
+						$each: ['TOOL_CREATE'],
+					},
+				},
+			}
+		).exec();
+
+		await close();
+	},
+
+	down: async function down() {
+		await connect();
+
+		await Roles.updateOne(
+			{ name: 'student' },
+			{
+				$pull: {
+					permissions: {
+						$in: ['TOOL_CREATE'],
+					},
+				},
+			}
+		).exec();
+
+		await close();
+	},
+};


### PR DESCRIPTION
# Description
A student could not create a topic with and add an Etherpad to it. 
He got an error: No Etherpad could be added to the course. If you see this message again, please contact support. 

I added permission for a student to create a topic with an etherpad only within a group. 
The teacher has the right to create a topic within the group and within the course. And the student only within the group.

## Links to Tickets or other pull requests

- https://ticketsystem.dbildungscloud.de/browse/BC-1530


## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review

- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
