### PR TITLE
N21-241 Changed property default name to defaultValue

### DIFF
--- a/apps/server/src/modules/tool/controller/dto/request/custom-parameter.params.ts
+++ b/apps/server/src/modules/tool/controller/dto/request/custom-parameter.params.ts
@@ -14,7 +14,7 @@ export class CustomParameterPostParams {
 	@IsString()
 	@IsOptional()
 	@ApiPropertyOptional()
-	default?: string;
+	defaultValue?: string;
 
 	@IsString()
 	@IsOptional()

--- a/apps/server/src/modules/tool/controller/dto/response/custom-parameter.response.ts
+++ b/apps/server/src/modules/tool/controller/dto/response/custom-parameter.response.ts
@@ -10,7 +10,7 @@ export class CustomParameterResponse {
 	name: string;
 
 	@ApiPropertyOptional()
-	default?: string;
+	defaultValue?: string;
 
 	@ApiPropertyOptional()
 	regex?: string;
@@ -32,7 +32,7 @@ export class CustomParameterResponse {
 
 	constructor(props: CustomParameterResponse) {
 		this.name = props.name;
-		this.default = props.default;
+		this.defaultValue = props.defaultValue;
 		this.location = props.location;
 		this.scope = props.scope;
 		this.type = props.type;

--- a/apps/server/src/modules/tool/controller/mapper/external-tool-request.mapper.spec.ts
+++ b/apps/server/src/modules/tool/controller/mapper/external-tool-request.mapper.spec.ts
@@ -58,7 +58,7 @@ describe('ExternalToolRequestMapper', () => {
 
 		const customParameterPostParams = new CustomParameterPostParams();
 		customParameterPostParams.name = 'mockName';
-		customParameterPostParams.default = 'mockDefault';
+		customParameterPostParams.defaultValue = 'mockDefault';
 		customParameterPostParams.location = CustomParameterLocationParams.PATH;
 		customParameterPostParams.scope = CustomParameterScopeParams.SCHOOL;
 		customParameterPostParams.type = CustomParameterTypeParams.STRING;

--- a/apps/server/src/modules/tool/controller/mapper/external-tool-request.mapper.ts
+++ b/apps/server/src/modules/tool/controller/mapper/external-tool-request.mapper.ts
@@ -99,7 +99,7 @@ export class ExternalToolRequestMapper {
 		return customParameterParams.map((customParameterParam: CustomParameterPostParams) => {
 			return {
 				name: customParameterParam.name,
-				default: customParameterParam.default,
+				default: customParameterParam.defaultValue,
 				regex: customParameterParam.regex,
 				regexComment: customParameterParam.regexComment,
 				scope: scopeMapping[customParameterParam.scope],

--- a/apps/server/src/modules/tool/controller/mapper/external-tool-response.mapper.spec.ts
+++ b/apps/server/src/modules/tool/controller/mapper/external-tool-response.mapper.spec.ts
@@ -48,7 +48,7 @@ describe('ExternalToolResponseMapper', () => {
 	const setup = () => {
 		const customParameterResponse: CustomParameterResponse = new CustomParameterResponse({
 			name: 'mockName',
-			default: 'mockDefault',
+			defaultValue: 'mockDefault',
 			location: CustomParameterLocationParams.PATH,
 			scope: CustomParameterScopeParams.SCHOOL,
 			type: CustomParameterTypeParams.STRING,
@@ -230,6 +230,7 @@ describe('ExternalToolResponseMapper', () => {
 						location: CustomParameterLocation.PATH,
 						name: 'customParameter',
 						isOptional: false,
+						default: 'defaultValue',
 					})
 					.buildWithId(
 						{
@@ -250,6 +251,7 @@ describe('ExternalToolResponseMapper', () => {
 							location: CustomParameterLocationParams.PATH,
 							name: 'customParameter',
 							isOptional: false,
+							defaultValue: 'defaultValue',
 						}),
 					],
 					version: 1,

--- a/apps/server/src/modules/tool/controller/mapper/external-tool-response.mapper.ts
+++ b/apps/server/src/modules/tool/controller/mapper/external-tool-response.mapper.ts
@@ -85,7 +85,7 @@ export class ExternalToolResponseMapper {
 		return customParameterDOS.map((customParameterDO: CustomParameterDO) => {
 			return {
 				name: customParameterDO.name,
-				default: customParameterDO.default,
+				defaultValue: customParameterDO.default,
 				regex: customParameterDO.regex,
 				regexComment: customParameterDO.regexComment,
 				scope: scopeMapping[customParameterDO.scope],

--- a/apps/server/src/modules/tool/controller/tool.controller.spec.ts
+++ b/apps/server/src/modules/tool/controller/tool.controller.spec.ts
@@ -98,7 +98,7 @@ describe('ToolController', () => {
 
 		const customParameterResponse: CustomParameterResponse = new CustomParameterResponse({
 			name: 'mockName',
-			default: 'mockDefault',
+			defaultValue: 'mockDefault',
 			location: CustomParameterLocationParams.PATH,
 			scope: CustomParameterScopeParams.SCHOOL,
 			type: CustomParameterTypeParams.STRING,
@@ -174,7 +174,7 @@ describe('ToolController', () => {
 		const setupCreate = () => {
 			const customParameterCreateParams = new CustomParameterPostParams();
 			customParameterCreateParams.name = 'mockName';
-			customParameterCreateParams.default = 'mockDefault';
+			customParameterCreateParams.defaultValue = 'mockDefault';
 			customParameterCreateParams.location = CustomParameterLocationParams.PATH;
 			customParameterCreateParams.scope = CustomParameterScopeParams.SCHOOL;
 			customParameterCreateParams.type = CustomParameterTypeParams.STRING;
@@ -460,7 +460,7 @@ describe('ToolController', () => {
 
 			const customParameterPostParams = new CustomParameterPostParams();
 			customParameterPostParams.name = 'mockName';
-			customParameterPostParams.default = 'mockDefault';
+			customParameterPostParams.defaultValue = 'mockDefault';
 			customParameterPostParams.location = CustomParameterLocationParams.PATH;
 			customParameterPostParams.scope = CustomParameterScopeParams.SCHOOL;
 			customParameterPostParams.type = CustomParameterTypeParams.STRING;

--- a/apps/server/src/modules/tool/controller/tool.controller.ts
+++ b/apps/server/src/modules/tool/controller/tool.controller.ts
@@ -74,7 +74,7 @@ export class ToolController {
 		const externalToolDO: CreateExternalTool = this.externalToolDOMapper.mapCreateRequest(externalToolParams);
 		const created: ExternalToolDO = await this.externalToolUc.createExternalTool(currentUser.userId, externalToolDO);
 		const mapped: ExternalToolResponse = this.externalResponseMapper.mapToResponse(created);
-		this.logger.debug(`ExternaTool with id ${mapped.id} was created by user with id ${currentUser.userId}`);
+		this.logger.debug(`ExternalTool with id ${mapped.id} was created by user with id ${currentUser.userId}`);
 		return mapped;
 	}
 
@@ -133,14 +133,14 @@ export class ToolController {
 			externalTool
 		);
 		const mapped: ExternalToolResponse = this.externalResponseMapper.mapToResponse(updated);
-		this.logger.debug(`ExternaTool with id ${mapped.id} was updated by user with id ${currentUser.userId}`);
+		this.logger.debug(`ExternalTool with id ${mapped.id} was updated by user with id ${currentUser.userId}`);
 		return mapped;
 	}
 
 	@Delete(':toolId')
 	async deleteExternalTool(@CurrentUser() currentUser: ICurrentUser, @Param() params: ToolIdParams): Promise<void> {
 		const promise: Promise<void> = this.externalToolUc.deleteExternalTool(currentUser.userId, params.toolId);
-		this.logger.debug(`ExternaTool with id ${params.toolId} was deleted by user with id ${currentUser.userId}`);
+		this.logger.debug(`ExternalTool with id ${params.toolId} was deleted by user with id ${currentUser.userId}`);
 		return promise;
 	}
 }


### PR DESCRIPTION
N21-241 Changed property default name to defaultValue because openapi generator makes this property private as _default

# Description
<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the begining of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
https://github.com/hpi-schul-cloud/superhero-dashboard/pull/199
https://ticketsystem.dbildungscloud.de/browse/N21-241
https://github.com/hpi-schul-cloud/nuxt-client/pull/2382
<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
