### PR TITLE
BC-3364 Update the HOMEWORK_CREATE and HOMEWORK_EDIT permissions

### DIFF
--- a/backup/setup/migrations.json
+++ b/backup/setup/migrations.json
@@ -130,5 +130,16 @@
 			"$date": "2023-02-14T08:58:00.462Z"
 		},
 		"__v": 0
+	},
+	{
+		"_id": {
+			"$oid": "63ff2eec033f9b6e70afc6d4"
+		},
+		"state": "up",
+		"name": "EditHomeworkCreateAndEditPermissions",
+		"createdAt": {
+			"$date": "2023-03-01T10:40:42.101Z"
+		},
+		"__v": 0
 	}
 ]

--- a/backup/setup/roles.json
+++ b/backup/setup/roles.json
@@ -6,7 +6,7 @@
 		"name": "user",
 		"roles": [],
 		"updatedAt": {
-			"$date": "2022-05-20T13:33:18.085Z"
+			"$date": "2023-03-01T10:54:36.810Z"
 		},
 		"createdAt": {
 			"$date": "2017-01-01T00:06:37.148Z"
@@ -38,8 +38,6 @@
 			"FOLDER_CREATE",
 			"FOLDER_DELETE",
 			"HELPDESK_CREATE",
-			"HOMEWORK_CREATE",
-			"HOMEWORK_EDIT",
 			"HOMEWORK_VIEW",
 			"LERNSTORE_VIEW",
 			"LINK_CREATE",
@@ -201,7 +199,7 @@
 		},
 		"name": "teacher",
 		"updatedAt": {
-			"$date": "2023-02-13T22:33:26.733Z"
+			"$date": "2023-03-01T10:54:36.797Z"
 		},
 		"createdAt": {
 			"$date": "2017-01-01T00:06:37.148Z"
@@ -247,7 +245,9 @@
 			"TASK_CARD_EDIT",
 			"TEAM_CREATE",
 			"TEAM_EDIT",
-			"START_MEETING"
+			"START_MEETING",
+			"HOMEWORK_CREATE",
+			"HOMEWORK_EDIT"
 		],
 		"__v": 2
 	},
@@ -425,7 +425,7 @@
 		},
 		"name": "courseStudent",
 		"updatedAt": {
-			"$date": "2022-05-20T13:33:18.077Z"
+			"$date": "2023-03-01T10:54:36.810Z"
 		},
 		"createdAt": {
 			"$date": "2019-09-09T12:00:00Z"
@@ -441,8 +441,6 @@
 			"COURSEGROUP_EDIT",
 			"LESSONS_VIEW",
 			"HOMEWORK_VIEW",
-			"HOMEWORK_EDIT",
-			"HOMEWORK_CREATE",
 			"COMMENTS_VIEW",
 			"COMMENTS_CREATE",
 			"COMMENTS_EDIT",

--- a/migrations/1677667242101-EditHomeworkCreateAndEditPermissions.js
+++ b/migrations/1677667242101-EditHomeworkCreateAndEditPermissions.js
@@ -1,0 +1,94 @@
+const mongoose = require('mongoose');
+// eslint-disable-next-line no-unused-vars
+const { alert, error } = require('../src/logger');
+
+const { connect, close } = require('../src/utils/database');
+
+// use your own name for your model, otherwise other migrations may fail.
+// The third parameter is the actually relevent one for what collection to write to.
+const Roles = mongoose.model(
+	'role_202304011545',
+	new mongoose.Schema(
+		{
+			name: { type: String, required: true },
+			permissions: [{ type: String }],
+		},
+		{
+			timestamps: true,
+		}
+	),
+	'roles'
+);
+
+module.exports = {
+	up: async function up() {
+		await connect();
+
+		await Roles.updateOne(
+			{
+				name: 'teacher',
+			},
+			{
+				$addToSet: {
+					permissions: {
+						$each: ['HOMEWORK_CREATE', 'HOMEWORK_EDIT'],
+					},
+				},
+			}
+		).exec();
+		alert(`Permission HOMEWORK_CREATE and HOMEWORK_EDIT added to role teacher`);
+
+		await Roles.updateMany(
+			{
+				name: {
+					$in: ['user', 'courseStudent'],
+				},
+			},
+			{
+				$pull: {
+					permissions: {
+						$in: ['HOMEWORK_CREATE', 'HOMEWORK_EDIT'],
+					},
+				},
+			}
+		).exec();
+
+		alert(`Permission HOMEWORK_CREATE and HOMEWORK_EDIT removed from role user and courseStudent`);
+	},
+
+	down: async function down() {
+		await connect();
+
+		await Roles.updateMany(
+			{
+				name: {
+					$in: ['user', 'courseStudent'],
+				},
+			},
+			{
+				$addToSet: {
+					permissions: {
+						$each: ['HOMEWORK_CREATE', 'HOMEWORK_EDIT'],
+					},
+				},
+			}
+		).exec();
+		alert(`Permission HOMEWORK_CREATE and HOMEWORK_EDIT added to role user and courseStudent`);
+
+		await Roles.updateOne(
+			{
+				name: 'teacher',
+			},
+			{
+				$pull: {
+					permissions: {
+						$in: ['HOMEWORK_CREATE', 'HOMEWORK_EDIT'],
+					},
+				},
+			}
+		).exec();
+		alert(`Permission HOMEWORK_CREATE and HOMEWORK_EDIT removed from role teacher`);
+
+		await close();
+	},
+};


### PR DESCRIPTION
# Description
Update the HOMEWORK_CREATE and HOMEWORK_EDIT permissions so that only the teacher, courseTeacher, courseSubstitutionTeacher has them.

## Links to Tickets or other pull requests
- https://ticketsystem.dbildungscloud.de/browse/BC-3364

## Changes
Remove permissions from user, courseStudent role and add them to teacher (as courseTeacher, courseSubstitutionTeacher already has them).

## Datasecurity

## Deployment

## New Repos, NPM pakages or vendor scripts

## Approval for review

- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
