### PR TITLE
EW-481 Re-work IDP hint handling

### DIFF
--- a/ansible/roles/schulcloud-server-init/templates/configmap_file_init.yml.j2
+++ b/ansible/roles/schulcloud-server-init/templates/configmap_file_init.yml.j2
@@ -76,7 +76,7 @@ data:
         }
       },
       "oidcConfig": {
-        "alias": "schoolOne0",
+        "idpHint": "schoolOne0",
         "clientId": "'${OIDCMOCK__CLIENT_ID}'",
         "clientSecret": "'${OIDCMOCK_CLIENT_SECRET}'",
         "authorizationUrl": "'${OIDCMOCK__BASE_URL}'/connect/authorize",

--- a/apps/server/src/modules/oauth/service/hydra.service.spec.ts
+++ b/apps/server/src/modules/oauth/service/hydra.service.spec.ts
@@ -54,7 +54,6 @@ describe('HydraService', () => {
 	const oauthConfig: OauthConfig = new OauthConfig({
 		clientId: '12345',
 		clientSecret: 'mocksecret',
-		alias: 'hydra',
 		tokenEndpoint: `${hydraUri}/oauth2/token`,
 		grantType: 'authorization_code',
 		redirectUri: `${apiHost}/api/v3/sso/hydra/12345`,

--- a/apps/server/src/modules/oauth/service/hydra.service.ts
+++ b/apps/server/src/modules/oauth/service/hydra.service.ts
@@ -108,7 +108,6 @@ export class HydraSsoService {
 			issuer: `${hydraUri}/`,
 			jwksEndpoint: `${hydraUri}/.well-known/jwks.json`,
 			logoutEndpoint: `${hydraUri}/oauth2/sessions/logout`,
-			alias: 'hydra',
 			provider: 'hydra',
 			redirectUri: `${Configuration.get('HOST') as string}/api/v3/sso/hydra/${oauthClientId}`,
 			responseType: 'code',

--- a/apps/server/src/modules/oauth/service/oauth.service.spec.ts
+++ b/apps/server/src/modules/oauth/service/oauth.service.spec.ts
@@ -244,7 +244,6 @@ describe('OAuthService', () => {
 			const oauthConfig: OauthConfigDto = new OauthConfigDto({
 				clientId: '12345',
 				clientSecret: 'mocksecret',
-				alias: 'alias',
 				tokenEndpoint: 'http://mock.de/mock/auth/public/mockToken',
 				grantType: 'authorization_code',
 				scope: 'openid uuid',
@@ -474,7 +473,6 @@ describe('OAuthService', () => {
 		describe('when a normal authentication url is requested', () => {
 			it('should return a authentication url', () => {
 				const oauthConfig: OauthConfig = new OauthConfig({
-					alias: 'alias',
 					clientId: '12345',
 					clientSecret: 'mocksecret',
 					tokenEndpoint: 'http://mock.de/mock/auth/public/mockToken',
@@ -489,10 +487,10 @@ describe('OAuthService', () => {
 					jwksEndpoint: 'http://mock.de/jwks',
 				});
 
-				const result: string = service.getAuthenticationUrl('oidc', oauthConfig, 'state', false, 'alias');
+				const result: string = service.getAuthenticationUrl(oauthConfig, 'state', false);
 
 				expect(result).toEqual(
-					'http://mock.de/auth?client_id=12345&redirect_uri=https%3A%2F%2Fmock.de%2Fapi%2Fv3%2Fsso%2Foauth&response_type=code&scope=openid+uuid&state=state&kc_idp_hint=alias'
+					'http://mock.de/auth?client_id=12345&redirect_uri=https%3A%2F%2Fmock.de%2Fapi%2Fv3%2Fsso%2Foauth&response_type=code&scope=openid+uuid&state=state'
 				);
 			});
 		});
@@ -500,7 +498,6 @@ describe('OAuthService', () => {
 		describe('when a migration authentication url is requested', () => {
 			it('should return a authentication url', () => {
 				const oauthConfig: OauthConfig = new OauthConfig({
-					alias: 'alias',
 					clientId: '12345',
 					clientSecret: 'mocksecret',
 					tokenEndpoint: 'http://mock.de/mock/auth/public/mockToken',
@@ -515,10 +512,33 @@ describe('OAuthService', () => {
 					jwksEndpoint: 'http://mock.de/jwks',
 				});
 
-				const result: string = service.getAuthenticationUrl('oidc', oauthConfig, 'state', true, 'alias');
+				const result: string = service.getAuthenticationUrl(oauthConfig, 'state', true);
 
 				expect(result).toEqual(
-					'http://mock.de/auth?client_id=12345&redirect_uri=https%3A%2F%2Fmock.de%2Fapi%2Fv3%2Fsso%2Foauth%2Fmigration&response_type=code&scope=openid+uuid&state=state&kc_idp_hint=alias'
+					'http://mock.de/auth?client_id=12345&redirect_uri=https%3A%2F%2Fmock.de%2Fapi%2Fv3%2Fsso%2Foauth%2Fmigration&response_type=code&scope=openid+uuid&state=state'
+				);
+			});
+			it('should return add an idp hint if existing authentication url', () => {
+				const oauthConfig: OauthConfig = new OauthConfig({
+					clientId: '12345',
+					clientSecret: 'mocksecret',
+					tokenEndpoint: 'http://mock.de/mock/auth/public/mockToken',
+					grantType: 'authorization_code',
+					redirectUri: 'http://mockhost.de/api/v3/sso/oauth/testsystemId',
+					scope: 'openid uuid',
+					responseType: 'code',
+					authEndpoint: 'http://mock.de/auth',
+					provider: 'mock_type',
+					logoutEndpoint: 'http://mock.de/logout',
+					issuer: 'mock_issuer',
+					jwksEndpoint: 'http://mock.de/jwks',
+					idpHint: 'TheIdpHint',
+				});
+
+				const result: string = service.getAuthenticationUrl(oauthConfig, 'state', true);
+
+				expect(result).toEqual(
+					'http://mock.de/auth?client_id=12345&redirect_uri=https%3A%2F%2Fmock.de%2Fapi%2Fv3%2Fsso%2Foauth%2Fmigration&response_type=code&scope=openid+uuid&state=state&kc_idp_hint=TheIdpHint'
 				);
 			});
 		});

--- a/apps/server/src/modules/oauth/service/oauth.service.ts
+++ b/apps/server/src/modules/oauth/service/oauth.service.ts
@@ -175,7 +175,7 @@ export class OAuthService {
 		authenticationUrl.searchParams.append('response_type', oauthConfig.responseType);
 		authenticationUrl.searchParams.append('scope', oauthConfig.scope);
 		authenticationUrl.searchParams.append('state', state);
-		if (alias && type === 'oidc') {
+		if (alias) {
 			authenticationUrl.searchParams.append('kc_idp_hint', alias);
 		}
 

--- a/apps/server/src/modules/oauth/service/oauth.service.ts
+++ b/apps/server/src/modules/oauth/service/oauth.service.ts
@@ -160,13 +160,7 @@ export class OAuthService {
 		return redirect;
 	}
 
-	getAuthenticationUrl(
-		type: string,
-		oauthConfig: OauthConfig,
-		state: string,
-		migration: boolean,
-		alias?: string
-	): string {
+	getAuthenticationUrl(oauthConfig: OauthConfig, state: string, migration: boolean): string {
 		const redirectUri: string = this.getRedirectUri(migration);
 
 		const authenticationUrl: URL = new URL(oauthConfig.authEndpoint);
@@ -175,8 +169,8 @@ export class OAuthService {
 		authenticationUrl.searchParams.append('response_type', oauthConfig.responseType);
 		authenticationUrl.searchParams.append('scope', oauthConfig.scope);
 		authenticationUrl.searchParams.append('state', state);
-		if (alias) {
-			authenticationUrl.searchParams.append('kc_idp_hint', alias);
+		if (oauthConfig.idpHint) {
+			authenticationUrl.searchParams.append('kc_idp_hint', oauthConfig.idpHint);
 		}
 
 		return authenticationUrl.toString();

--- a/apps/server/src/modules/oauth/uc/hydra-oauth.uc.spec.ts
+++ b/apps/server/src/modules/oauth/uc/hydra-oauth.uc.spec.ts
@@ -44,7 +44,6 @@ describe('HydraOauthUc', () => {
 		authEndpoint: `${hydraUri}/oauth2/auth`,
 		clientId: 'toolClientId',
 		clientSecret: 'toolSecret',
-		alias: 'alias',
 		grantType: 'authorization_code',
 		issuer: `${hydraUri}/`,
 		jwksEndpoint: `${hydraUri}/.well-known/jwks.json`,

--- a/apps/server/src/modules/oauth/uc/oauth.uc.spec.ts
+++ b/apps/server/src/modules/oauth/uc/oauth.uc.spec.ts
@@ -121,7 +121,6 @@ describe('OAuthUc', () => {
 		const setup = () => {
 			const systemId = 'systemId';
 			const oauthConfig: OauthConfigDto = new OauthConfigDto({
-				alias: 'alias',
 				clientId: '12345',
 				clientSecret: 'mocksecret',
 				tokenEndpoint: 'http://mock.de/mock/auth/public/mockToken',
@@ -317,7 +316,6 @@ describe('OAuthUc', () => {
 			});
 
 			const oauthConfig: OauthConfigDto = new OauthConfigDto({
-				alias: 'alias',
 				clientId: '12345',
 				clientSecret: 'mocksecret',
 				tokenEndpoint: 'http://mock.de/mock/auth/public/mockToken',

--- a/apps/server/src/modules/oauth/uc/oauth.uc.ts
+++ b/apps/server/src/modules/oauth/uc/oauth.uc.ts
@@ -55,11 +55,9 @@ export class OauthUc {
 		}
 
 		const authenticationUrl: string = this.oauthService.getAuthenticationUrl(
-			system.type,
 			system.oauthConfig,
 			state,
 			migration,
-			system.alias
 		);
 
 		session.oauthLoginState = new OauthLoginStateDto({

--- a/apps/server/src/modules/oauth/uc/oauth.uc.ts
+++ b/apps/server/src/modules/oauth/uc/oauth.uc.ts
@@ -54,11 +54,7 @@ export class OauthUc {
 			throw new UnprocessableEntityException(`Requested system ${systemId} has no oauth configured`);
 		}
 
-		const authenticationUrl: string = this.oauthService.getAuthenticationUrl(
-			system.oauthConfig,
-			state,
-			migration,
-		);
+		const authenticationUrl: string = this.oauthService.getAuthenticationUrl(system.oauthConfig, state, migration);
 
 		session.oauthLoginState = new OauthLoginStateDto({
 			state,

--- a/apps/server/src/modules/system/controller/dto/oauth-config.response.ts
+++ b/apps/server/src/modules/system/controller/dto/oauth-config.response.ts
@@ -9,11 +9,11 @@ export class OauthConfigResponse {
 	clientId: string;
 
 	@ApiProperty({
-		description: 'An alias',
+		description: 'Hint for idp redirects (optional)',
 		required: false,
 		nullable: true,
 	})
-	alias: string;
+	idpHint?: string;
 
 	@ApiProperty({
 		description: 'Redirect uri',
@@ -87,7 +87,7 @@ export class OauthConfigResponse {
 
 	constructor(oauthConfigResponse: {
 		redirectUri: string;
-		alias: string;
+		idpHint?: string;
 		tokenEndpoint: string;
 		responseType: string;
 		clientId: string;
@@ -100,7 +100,7 @@ export class OauthConfigResponse {
 		issuer: string;
 	}) {
 		this.clientId = oauthConfigResponse.clientId;
-		this.alias = oauthConfigResponse.alias;
+		this.idpHint = oauthConfigResponse.idpHint;
 		this.redirectUri = oauthConfigResponse.redirectUri;
 		this.grantType = oauthConfigResponse.grantType;
 		this.tokenEndpoint = oauthConfigResponse.tokenEndpoint;

--- a/apps/server/src/modules/system/controller/mapper/system-oauth-response.mapper.spec.ts
+++ b/apps/server/src/modules/system/controller/mapper/system-oauth-response.mapper.spec.ts
@@ -8,7 +8,7 @@ import { SystemResponseMapper } from './system-response.mapper';
 function assertOauthConfig(expected: OauthConfigDto | undefined, actual: OauthConfigResponse | undefined): boolean {
 	if (expected != null && actual != null) {
 		expect(actual.clientId).toBe(expected.clientId);
-		expect(actual.alias).toBe(expected.alias);
+		expect(actual.idpHint).toBe(expected.idpHint);
 		expect(actual.grantType).toBe(expected.grantType);
 		expect(actual.tokenEndpoint).toBe(expected.tokenEndpoint);
 		expect(actual.authEndpoint).toBe(expected.authEndpoint);
@@ -28,7 +28,6 @@ describe('oauth-response mapper', () => {
 	let module: TestingModule;
 	const defaultOauthConfigDto = new OauthConfigDto({
 		clientId: '12345',
-		alias: 'alias-mock',
 		clientSecret: 'mocksecret',
 		tokenEndpoint: 'http://mock.de/mock/auth/public/mockToken',
 		grantType: 'authorization_code',

--- a/apps/server/src/modules/system/controller/mapper/system-response.mapper.ts
+++ b/apps/server/src/modules/system/controller/mapper/system-response.mapper.ts
@@ -28,7 +28,7 @@ export class SystemResponseMapper {
 		return new OauthConfigResponse({
 			clientId: oauthConfigDto.clientId,
 			// clientSecret will not be mapped for security reasons,
-			alias: oauthConfigDto.alias,
+			idpHint: oauthConfigDto.idpHint,
 			redirectUri: oauthConfigDto.redirectUri,
 			grantType: oauthConfigDto.grantType,
 			tokenEndpoint: oauthConfigDto.tokenEndpoint,

--- a/apps/server/src/modules/system/mapper/system-oidc.mapper.spec.ts
+++ b/apps/server/src/modules/system/mapper/system-oidc.mapper.spec.ts
@@ -26,7 +26,7 @@ describe('SystemOidcMapper', () => {
 			expect(result?.parentSystemId).toEqual(systemEntity.id);
 			expect(result?.clientId).toEqual(systemEntity.oidcConfig?.clientId);
 			expect(result?.clientSecret).toEqual(systemEntity.oidcConfig?.clientSecret);
-			expect(result?.alias).toEqual(systemEntity.oidcConfig?.alias);
+			expect(result?.idpHint).toEqual(systemEntity.oidcConfig?.idpHint);
 			expect(result?.authorizationUrl).toEqual(systemEntity.oidcConfig?.authorizationUrl);
 			expect(result?.tokenUrl).toEqual(systemEntity.oidcConfig?.tokenUrl);
 			expect(result?.userinfoUrl).toEqual(systemEntity.oidcConfig?.userinfoUrl);
@@ -62,7 +62,7 @@ describe('SystemOidcMapper', () => {
 			expect(theResult.parentSystemId).toEqual(systemEntity.id);
 			expect(theResult.clientId).toEqual(systemEntity.oidcConfig?.clientId);
 			expect(theResult.clientSecret).toEqual(systemEntity.oidcConfig?.clientSecret);
-			expect(theResult.alias).toEqual(systemEntity.oidcConfig?.alias);
+			expect(theResult.idpHint).toEqual(systemEntity.oidcConfig?.idpHint);
 			expect(theResult.authorizationUrl).toEqual(systemEntity.oidcConfig?.authorizationUrl);
 			expect(theResult.tokenUrl).toEqual(systemEntity.oidcConfig?.tokenUrl);
 			expect(theResult.userinfoUrl).toEqual(systemEntity.oidcConfig?.userinfoUrl);

--- a/apps/server/src/modules/system/mapper/system-oidc.mapper.ts
+++ b/apps/server/src/modules/system/mapper/system-oidc.mapper.ts
@@ -14,7 +14,7 @@ export class SystemOidcMapper {
 			parentSystemId: systemId,
 			clientId: oidcConfig.clientId,
 			clientSecret: oidcConfig?.clientSecret,
-			alias: oidcConfig.alias,
+			idpHint: oidcConfig.idpHint,
 			authorizationUrl: oidcConfig.authorizationUrl,
 			tokenUrl: oidcConfig.tokenUrl,
 			userinfoUrl: oidcConfig.userinfoUrl,

--- a/apps/server/src/modules/system/mapper/system.mapper.ts
+++ b/apps/server/src/modules/system/mapper/system.mapper.ts
@@ -21,7 +21,7 @@ export class SystemMapper {
 		return new OauthConfigDto({
 			clientId: oauthConfig.clientId,
 			clientSecret: oauthConfig.clientSecret,
-			alias: oauthConfig.alias,
+			idpHint: oauthConfig.idpHint,
 			redirectUri: oauthConfig.redirectUri,
 			grantType: oauthConfig.grantType,
 			tokenEndpoint: oauthConfig.tokenEndpoint,

--- a/apps/server/src/modules/system/service/dto/oauth-config.dto.ts
+++ b/apps/server/src/modules/system/service/dto/oauth-config.dto.ts
@@ -3,7 +3,7 @@ export class OauthConfigDto {
 
 	clientSecret: string;
 
-	alias: string;
+	idpHint?: string;
 
 	redirectUri: string;
 
@@ -28,7 +28,7 @@ export class OauthConfigDto {
 	constructor(oauthConfigDto: OauthConfigDto) {
 		this.clientId = oauthConfigDto.clientId;
 		this.clientSecret = oauthConfigDto.clientSecret;
-		this.alias = oauthConfigDto.alias;
+		this.idpHint = oauthConfigDto.idpHint;
 		this.redirectUri = oauthConfigDto.redirectUri;
 		this.grantType = oauthConfigDto.grantType;
 		this.tokenEndpoint = oauthConfigDto.tokenEndpoint;

--- a/apps/server/src/modules/system/service/dto/oidc-config.dto.ts
+++ b/apps/server/src/modules/system/service/dto/oidc-config.dto.ts
@@ -3,7 +3,7 @@ export class OidcConfigDto {
 		this.parentSystemId = oidcConfigDto.parentSystemId;
 		this.clientId = oidcConfigDto.clientId;
 		this.clientSecret = oidcConfigDto.clientSecret;
-		this.alias = oidcConfigDto.alias;
+		this.idpHint = oidcConfigDto.idpHint;
 		this.authorizationUrl = oidcConfigDto.authorizationUrl;
 		this.tokenUrl = oidcConfigDto.tokenUrl;
 		this.userinfoUrl = oidcConfigDto.userinfoUrl;
@@ -17,7 +17,7 @@ export class OidcConfigDto {
 
 	clientSecret: string;
 
-	alias: string;
+	idpHint: string;
 
 	authorizationUrl: string;
 

--- a/apps/server/src/modules/system/service/system.service.spec.ts
+++ b/apps/server/src/modules/system/service/system.service.spec.ts
@@ -77,7 +77,7 @@ describe('SystemService', () => {
 						oauthConfig: expect.objectContaining({
 							clientId: oauthSystem.oauthConfig.clientId,
 							clientSecret: oauthSystem.oauthConfig.clientSecret,
-							alias: oidcSystem.oidcConfig?.alias ?? '',
+							idpHint: oidcSystem.oidcConfig?.idpHint,
 							redirectUri: oauthSystem.oauthConfig.redirectUri + oidcSystem.id,
 							grantType: oauthSystem.oauthConfig.grantType,
 							tokenEndpoint: oauthSystem.oauthConfig.tokenEndpoint,
@@ -169,7 +169,7 @@ describe('SystemService', () => {
 							oauthConfig: expect.objectContaining({
 								clientId: oauthSystem.oauthConfig.clientId,
 								clientSecret: oauthSystem.oauthConfig.clientSecret,
-								alias: oidcSystem.oidcConfig?.alias ?? '',
+								idpHint: oidcSystem.oidcConfig?.idpHint,
 								redirectUri: oauthSystem.oauthConfig.redirectUri + oidcSystem.id,
 								grantType: oauthSystem.oauthConfig.grantType,
 								tokenEndpoint: oauthSystem.oauthConfig.tokenEndpoint,

--- a/apps/server/src/modules/system/service/system.service.ts
+++ b/apps/server/src/modules/system/service/system.service.ts
@@ -81,7 +81,7 @@ export class SystemService {
 				});
 				generatedSystem.id = system.id;
 				generatedSystem.oauthConfig = { ...brokerConfig };
-				generatedSystem.oauthConfig.alias = system.oidcConfig.alias;
+				generatedSystem.oauthConfig.idpHint = system.oidcConfig.idpHint;
 				generatedSystem.oauthConfig.redirectUri += system.id;
 				return generatedSystem;
 			}

--- a/apps/server/src/modules/user-login-migration/service/user-migration.service.spec.ts
+++ b/apps/server/src/modules/user-login-migration/service/user-migration.service.spec.ts
@@ -163,7 +163,6 @@ describe('UserMigrationService', () => {
 			const sourceOauthConfig: OauthConfigDto = new OauthConfigDto({
 				clientId: 'sourceClientId',
 				clientSecret: 'sourceSecret',
-				alias: 'alias',
 				tokenEndpoint: 'http://source.de/auth/public/mockToken',
 				grantType: 'authorization_code',
 				scope: 'openid uuid',
@@ -178,7 +177,6 @@ describe('UserMigrationService', () => {
 			const targetOauthConfig: OauthConfigDto = new OauthConfigDto({
 				clientId: 'targetClientId',
 				clientSecret: 'targetSecret',
-				alias: 'alias',
 				tokenEndpoint: 'http://target.de/auth/public/mockToken',
 				grantType: 'authorization_code',
 				scope: 'openid uuid',

--- a/apps/server/src/shared/domain/entity/system.entity.spec.ts
+++ b/apps/server/src/shared/domain/entity/system.entity.spec.ts
@@ -45,7 +45,7 @@ describe('System Entity', () => {
 					oauthConfig: {
 						clientId: '12345',
 						clientSecret: 'mocksecret',
-						idpHint: 'mock-oauth-alias',
+						idpHint: 'mock-oauth-idpHint',
 						tokenEndpoint: 'http://mock.de/mock/auth/public/mockToken',
 						grantType: 'authorization_code',
 						redirectUri: 'http://mockhost:3030/api/v3/sso/oauth/',

--- a/apps/server/src/shared/domain/entity/system.entity.spec.ts
+++ b/apps/server/src/shared/domain/entity/system.entity.spec.ts
@@ -45,7 +45,7 @@ describe('System Entity', () => {
 					oauthConfig: {
 						clientId: '12345',
 						clientSecret: 'mocksecret',
-						alias: 'mock-oauth-alias',
+						idpHint: 'mock-oauth-alias',
 						tokenEndpoint: 'http://mock.de/mock/auth/public/mockToken',
 						grantType: 'authorization_code',
 						redirectUri: 'http://mockhost:3030/api/v3/sso/oauth/',

--- a/apps/server/src/shared/domain/entity/system.entity.ts
+++ b/apps/server/src/shared/domain/entity/system.entity.ts
@@ -19,7 +19,7 @@ export class OauthConfig {
 	constructor(oauthConfig: OauthConfig) {
 		this.clientId = oauthConfig.clientId;
 		this.clientSecret = oauthConfig.clientSecret;
-		this.alias = oauthConfig.alias;
+		this.idpHint = oauthConfig.idpHint;
 		this.tokenEndpoint = oauthConfig.tokenEndpoint;
 		this.grantType = oauthConfig.grantType;
 		this.redirectUri = oauthConfig.redirectUri;
@@ -38,8 +38,8 @@ export class OauthConfig {
 	@Property()
 	clientSecret: string;
 
-	@Property()
-	alias: string;
+	@Property({ nullable: true })
+	idpHint?: string;
 
 	@Property()
 	redirectUri: string;
@@ -143,7 +143,7 @@ export class OidcConfig {
 	constructor(oidcConfig: OidcConfig) {
 		this.clientId = oidcConfig.clientId;
 		this.clientSecret = oidcConfig.clientSecret;
-		this.alias = oidcConfig.alias;
+		this.idpHint = oidcConfig.idpHint;
 		this.authorizationUrl = oidcConfig.authorizationUrl;
 		this.tokenUrl = oidcConfig.tokenUrl;
 		this.logoutUrl = oidcConfig.logoutUrl;
@@ -158,7 +158,7 @@ export class OidcConfig {
 	clientSecret: string;
 
 	@Property()
-	alias: string;
+	idpHint: string;
 
 	@Property()
 	authorizationUrl: string;

--- a/apps/server/src/shared/infra/identity-management/keycloak-configuration/mapper/identity-provider.mapper.spec.ts
+++ b/apps/server/src/shared/infra/identity-management/keycloak-configuration/mapper/identity-provider.mapper.spec.ts
@@ -36,7 +36,7 @@ describe('OidcIdentityProviderMapper', () => {
 			parentSystemId: new ObjectId(0).toString(),
 			clientId: 'clientId',
 			clientSecret: 'clientSecret',
-			alias: 'alias',
+			idpHint: 'alias',
 			authorizationUrl: 'authorizationUrl',
 			tokenUrl: 'tokenUrl',
 			logoutUrl: 'logoutUrl',

--- a/apps/server/src/shared/infra/identity-management/keycloak-configuration/mapper/identity-provider.mapper.ts
+++ b/apps/server/src/shared/infra/identity-management/keycloak-configuration/mapper/identity-provider.mapper.ts
@@ -9,8 +9,8 @@ export class OidcIdentityProviderMapper {
 	public mapToKeycloakIdentityProvider(oidcConfig: OidcConfigDto, flowAlias: string): IdentityProviderRepresentation {
 		return {
 			providerId: 'oidc',
-			alias: oidcConfig.alias,
-			displayName: oidcConfig.alias,
+			alias: oidcConfig.idpHint,
+			displayName: oidcConfig.idpHint,
 			enabled: true,
 			firstBrokerLoginFlowAlias: flowAlias,
 			config: {

--- a/apps/server/src/shared/infra/identity-management/keycloak-configuration/service/keycloak-configuration.service.spec.ts
+++ b/apps/server/src/shared/infra/identity-management/keycloak-configuration/service/keycloak-configuration.service.spec.ts
@@ -68,7 +68,7 @@ describe('KeycloakConfigurationService Unit', () => {
 	const idps: IdentityProviderRepresentation[] = [
 		{
 			providerId: 'oidc',
-			alias: oidcSystems[0].alias,
+			alias: oidcSystems[0].idpHint,
 			enabled: true,
 			config: {
 				clientId: 'clientId',

--- a/apps/server/src/shared/infra/identity-management/keycloak-configuration/service/keycloak-configuration.service.ts
+++ b/apps/server/src/shared/infra/identity-management/keycloak-configuration/service/keycloak-configuration.service.ts
@@ -197,7 +197,7 @@ export class KeycloakConfigurationService {
 		)[];
 		// updating or creating configs
 		newConfigs.forEach((newConfig) => {
-			if (oldConfigs.some((oldConfig) => oldConfig.alias === newConfig.alias)) {
+			if (oldConfigs.some((oldConfig) => oldConfig.alias === newConfig.idpHint)) {
 				result.push({ action: ConfigureAction.UPDATE, config: newConfig });
 			} else {
 				result.push({ action: ConfigureAction.CREATE, config: newConfig });
@@ -205,7 +205,7 @@ export class KeycloakConfigurationService {
 		});
 		// deleting configs
 		oldConfigs.forEach((oldConfig) => {
-			if (!newConfigs.some((newConfig) => newConfig.alias === oldConfig.alias)) {
+			if (!newConfigs.some((newConfig) => newConfig.idpHint === oldConfig.alias)) {
 				result.push({ action: ConfigureAction.DELETE, alias: oldConfig.alias as string });
 			}
 		});
@@ -214,22 +214,22 @@ export class KeycloakConfigurationService {
 
 	private async createIdentityProvider(oidcConfig: OidcConfigDto): Promise<void> {
 		const kc = await this.kcAdmin.callKcAdminClient();
-		if (oidcConfig && oidcConfig?.alias) {
+		if (oidcConfig && oidcConfig?.idpHint) {
 			await kc.identityProviders.create(
 				this.oidcIdentityProviderMapper.mapToKeycloakIdentityProvider(oidcConfig, flowAlias)
 			);
-			await this.createIdpDefaultMapper(oidcConfig.alias);
+			await this.createIdpDefaultMapper(oidcConfig.idpHint);
 		}
 	}
 
 	private async updateIdentityProvider(oidcConfig: OidcConfigDto): Promise<void> {
 		const kc = await this.kcAdmin.callKcAdminClient();
-		if (oidcConfig && oidcConfig?.alias) {
+		if (oidcConfig && oidcConfig?.idpHint) {
 			await kc.identityProviders.update(
-				{ alias: oidcConfig.alias },
+				{ alias: oidcConfig.idpHint },
 				this.oidcIdentityProviderMapper.mapToKeycloakIdentityProvider(oidcConfig, flowAlias)
 			);
-			await this.updateOrCreateIdpDefaultMapper(oidcConfig.alias);
+			await this.updateOrCreateIdpDefaultMapper(oidcConfig.idpHint);
 		}
 	}
 

--- a/apps/server/src/shared/infra/identity-management/keycloak/service/keycloak-identity-management-oauth.service.ts
+++ b/apps/server/src/shared/infra/identity-management/keycloak/service/keycloak-identity-management-oauth.service.ts
@@ -33,7 +33,6 @@ export class KeycloakIdentityManagementOauthService extends IdentityManagementOa
 		this._oauthConfigCache = new OauthConfigDto({
 			clientId: this.kcAdminService.getClientId(),
 			clientSecret: this.oAuthEncryptionService.encrypt(await this.kcAdminService.getClientSecret()),
-			alias: 'keycloak',
 			provider: 'oauth',
 			redirectUri,
 			responseType: 'code',

--- a/apps/server/src/shared/testing/factory/system.factory.ts
+++ b/apps/server/src/shared/testing/factory/system.factory.ts
@@ -9,7 +9,6 @@ export class SystemFactory extends BaseFactory<System, ISystemProperties> {
 			oauthConfig: new OauthConfig({
 				clientId: '12345',
 				clientSecret: 'mocksecret',
-				alias: 'mock-oauth-alias',
 				tokenEndpoint: 'http://mock.de/mock/auth/public/mockToken',
 				grantType: 'authorization_code',
 				redirectUri: 'http://mockhost:3030/api/v3/sso/oauth/',
@@ -40,7 +39,7 @@ export class SystemFactory extends BaseFactory<System, ISystemProperties> {
 			oidcConfig: new OidcConfig({
 				clientId: 'mock-client-id',
 				clientSecret: 'mock-client-secret',
-				alias: 'mock-oidc-alias',
+				idpHint: 'mock-oidc-alias',
 				defaultScopes: 'openid email userinfo',
 				authorizationUrl: 'https://mock.tld/auth',
 				tokenUrl: 'https://mock.tld/token',

--- a/apps/server/src/shared/testing/factory/system.factory.ts
+++ b/apps/server/src/shared/testing/factory/system.factory.ts
@@ -9,6 +9,7 @@ export class SystemFactory extends BaseFactory<System, ISystemProperties> {
 			oauthConfig: new OauthConfig({
 				clientId: '12345',
 				clientSecret: 'mocksecret',
+				idpHint: 'mock-oauth-idpHint',
 				tokenEndpoint: 'http://mock.de/mock/auth/public/mockToken',
 				grantType: 'authorization_code',
 				redirectUri: 'http://mockhost:3030/api/v3/sso/oauth/',
@@ -39,7 +40,7 @@ export class SystemFactory extends BaseFactory<System, ISystemProperties> {
 			oidcConfig: new OidcConfig({
 				clientId: 'mock-client-id',
 				clientSecret: 'mock-client-secret',
-				idpHint: 'mock-oidc-alias',
+				idpHint: 'mock-oidc-idpHint',
 				defaultScopes: 'openid email userinfo',
 				authorizationUrl: 'https://mock.tld/auth',
 				tokenUrl: 'https://mock.tld/token',

--- a/backup/setup/migrations.json
+++ b/backup/setup/migrations.json
@@ -56,17 +56,6 @@
 	},
 	{
 		"_id": {
-			"$oid": "6308cf3bee02bf090ec3a491"
-		},
-		"state": "up",
-		"name": "clean-user-account",
-		"createdAt": {
-			"$date": "2022-08-25T14:19:14.069Z"
-		},
-		"__v": 0
-	},
-	{
-		"_id": {
 			"$oid": "632c5fafc744915f90d1c73b"
 		},
 		"state": "up",
@@ -139,6 +128,17 @@
 		"name": "EditHomeworkCreateAndEditPermissions",
 		"createdAt": {
 			"$date": "2023-03-01T10:40:42.101Z"
+		},
+		"__v": 0
+	},
+	{
+		"_id": {
+			"$oid": "64141f668fb9600ed8e0c11a"
+		},
+		"state": "up",
+		"name": "RefactorSystemSubConfig",
+		"createdAt": {
+			"$date": "2023-03-15T14:04:48.654Z"
 		},
 		"__v": 0
 	}

--- a/backup/setup/systems.json
+++ b/backup/setup/systems.json
@@ -12,7 +12,7 @@
 		"alias": "oidcmock",
 		"displayName": "OIDCMOCK",
 		"oidcConfig": {
-			"alias": "oidcmock",
+			"idpHint": "oidcmock",
 			"clientId": "${OIDCMOCK__CLIENT_ID}",
 			"clientSecret": "${OIDCMOCK__CLIENT_SECRET}",
 			"authorizationUrl": "${OIDCMOCK__BASE_URL}/connect/authorize",

--- a/migrations/1678889088654-RefactorSystemSubConfig.js
+++ b/migrations/1678889088654-RefactorSystemSubConfig.js
@@ -1,0 +1,64 @@
+const mongoose = require('mongoose');
+// eslint-disable-next-line no-unused-vars
+const { alert, error } = require('../src/logger');
+const { connect, close } = require('../src/utils/database');
+
+const System = mongoose.model(
+	'systemSchemaIdpHintRefactor',
+	new mongoose.Schema(
+		{
+			oauthConfig: {
+				type: {
+					alias: { type: String, required: false },
+				},
+				required: false,
+			},
+			oidcConfig: {
+				type: {
+					alias: { type: String, required: false },
+				},
+				required: false,
+			},
+		},
+		{
+			timestamps: true,
+		}
+	),
+	'systems'
+);
+
+// This migration renames a field and removes an unnecessary one
+
+module.exports = {
+	up: async function up() {
+		await connect();
+		await System.updateMany(
+			{ oidcConfig: { $ne: null }, 'oidcConfig.alias': { $exists: true } },
+			{ $rename: { 'oidcConfig.alias': 'oidcConfig.idpHint' } }
+		);
+		alert(`Renamed oidcConfig alias to idpHint`);
+		await System.updateMany(
+			{ oauthConfig: { $ne: null }, 'oauthConfig.alias': { $exists: true } },
+			{ $rename: { 'oauthConfig.alias': 'oauthConfig.idpHint' } }
+		);
+		alert(`Renamed oauthConfig alias to idpHint`);
+		alert(`...finished!`);
+		await close();
+	},
+
+	down: async function down() {
+		await connect();
+		await System.updateMany(
+			{ oidcConfig: { $ne: null }, 'oidcConfig.idpHint': { $exists: true } },
+			{ $rename: { 'oidcConfig.idpHint': 'oidcConfig.alias' } }
+		);
+		alert(`Renamed oidcConfig idpHint to alias`);
+		await System.updateMany(
+			{ oauthConfig: { $ne: null }, 'oauthConfig.idpHint': { $exists: true } },
+			{ $rename: { 'oauthConfig.idpHint': 'oauthConfig.alias' } }
+		);
+		alert(`Renamed oauthConfig idpHint to alias`);
+		alert(`...finished!`);
+		await close();
+	},
+};


### PR DESCRIPTION
# Description

Remove or reword 'alias' propertie in systems's oidc and oauth configs to 'idpHint'. The property is used to indicate 3rd party IDP to the ErWIn IDM during the oauth authentification process.

## Links to Tickets or other pull requests

- https://ticketsystem.dbildungscloud.de/browse/EW-481

## Changes

See description

## Datasecurity

NA

## Deployment

The migration '1678889088654-RefactorSystemSubConfig.js' needs to be executed (rename of 2 properties).

## New Repos, NPM pakages or vendor scripts

NA

## Approval for review

- [x] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
