### PR TITLE
BC-3860 - Fix code style duedate

### DIFF
--- a/apps/server/src/modules/learnroom/controller/dto/single-column-board/board-task.response.ts
+++ b/apps/server/src/modules/learnroom/controller/dto/single-column-board/board-task.response.ts
@@ -22,7 +22,7 @@ export class BoardTaskResponse {
 	availableDate?: Date;
 
 	@ApiPropertyOptional()
-	duedate?: Date;
+	dueDate?: Date;
 
 	@ApiPropertyOptional()
 	@DecodeHtmlEntities()

--- a/apps/server/src/modules/learnroom/mapper/room-board-response.mapper.ts
+++ b/apps/server/src/modules/learnroom/mapper/room-board-response.mapper.ts
@@ -56,7 +56,7 @@ export class RoomBoardResponseMapper {
 		const taskCourse = boardTask.course as Course;
 		mappedTask.courseName = taskCourse.name;
 		mappedTask.availableDate = boardTask.availableDate;
-		mappedTask.duedate = boardTask.dueDate;
+		mappedTask.dueDate = boardTask.dueDate;
 		mappedTask.displayColor = boardTaskDesc.color;
 		mappedTask.description = boardTask.description;
 		const boardElementResponse = new BoardElementResponse({

--- a/apps/server/src/modules/task/controller/api-test/task.api.spec.ts
+++ b/apps/server/src/modules/task/controller/api-test/task.api.spec.ts
@@ -4,7 +4,6 @@ import { EntityManager } from '@mikro-orm/mongodb';
 import { ExecutionContext, INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { InputFormat, Permission, Task } from '@shared/domain';
-import { ICurrentUser } from '@src/modules/authentication';
 import {
 	cleanupCollections,
 	courseFactory,
@@ -16,6 +15,7 @@ import {
 	userFactory,
 } from '@shared/testing';
 import { FilesStorageClientAdapterService } from '@src/modules';
+import { ICurrentUser } from '@src/modules/authentication';
 import { JwtAuthGuard } from '@src/modules/authentication/guard/jwt-auth.guard';
 import { ServerTestModule } from '@src/modules/server/server.module';
 import { TaskCreateParams, TaskListResponse, TaskResponse, TaskUpdateParams } from '@src/modules/task/controller/dto';
@@ -1271,7 +1271,7 @@ describe('Task Controller (API)', () => {
 				type: InputFormat.RICH_TEXT_CK5,
 			});
 			expect(responseTask.availableDate).toEqual(updateTaskParams.availableDate);
-			expect(responseTask.duedate).toEqual(updateTaskParams.dueDate);
+			expect(responseTask.dueDate).toEqual(updateTaskParams.dueDate);
 			expect(responseTask.courseId).toEqual(updateTaskParams.courseId);
 			expect(responseTask.lessonName).toEqual(lesson.name);
 			expect(responseTask.users).toEqual([

--- a/apps/server/src/modules/task/controller/dto/task.response.ts
+++ b/apps/server/src/modules/task/controller/dto/task.response.ts
@@ -35,7 +35,7 @@ export class TaskResponse {
 	availableDate?: Date;
 
 	@ApiPropertyOptional()
-	duedate?: Date;
+	dueDate?: Date;
 
 	@ApiProperty()
 	@DecodeHtmlEntities()

--- a/apps/server/src/modules/task/mapper/task.mapper.spec.ts
+++ b/apps/server/src/modules/task/mapper/task.mapper.spec.ts
@@ -32,7 +32,7 @@ const createExpectedResponse = (
 	if (task.taskCard) {
 		expected.taskCardId = task.taskCard;
 	}
-	expected.duedate = task.dueDate;
+	expected.dueDate = task.dueDate;
 	expected.updatedAt = task.updatedAt;
 	expected.status = expectedStatus;
 

--- a/apps/server/src/modules/task/mapper/task.mapper.ts
+++ b/apps/server/src/modules/task/mapper/task.mapper.ts
@@ -28,7 +28,7 @@ export class TaskMapper {
 			dto.taskCardId = task.taskCard;
 		}
 		dto.availableDate = task.availableDate;
-		dto.duedate = task.dueDate;
+		dto.dueDate = task.dueDate;
 
 		dto.displayColor = taskDesc.color;
 		if (taskDesc.lessonName) {


### PR DESCRIPTION
# Description
<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the begining of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->
in FE and BE the property for tasks and board tasks is defined as "duedate" and not (as it would be correct) "dueDate". This leads to development problems, as the issue can cause errors in case the dev assumes that it would be "dueDate" as in the database.
## Links to Tickets or other pull requests
<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->
BC-3860
## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->
- `duedate` usage changed to `dueDate` (as in database property)

## Approval for review

- [ ] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
