### PR TITLE
EW-129 Migrate existing accounts from MongoDB to ErWin-IDM/Keycloak

### DIFF
--- a/ansible/roles/schulcloud-server-core/tasks/main.yml
+++ b/ansible/roles/schulcloud-server-core/tasks/main.yml
@@ -84,3 +84,20 @@
       kubeconfig: ~/.kube/config
       namespace: "{{ NAMESPACE }}"
       template: amqp-files-deployment.yml.j2
+
+  - name: Remove old erwin account migration job
+    kubernetes.core.k8s:
+      kubeconfig: ~/.kube/config
+      namespace: "{{ NAMESPACE }}"
+      api_version: batch/v1
+      kind: Job
+      name: erwin-account-migration-job
+      state: absent
+      wait: yes
+
+  - name: Create erwin account migration job
+    kubernetes.core.k8s:
+      kubeconfig: ~/.kube/config
+      namespace: "{{ NAMESPACE }}"
+      template: erwin-account-migration-job.yml.j2
+    when: ERWINIDM_ACCOUNT_MIGRATION is defined and ERWINIDM_ACCOUNT_MIGRATION|bool

--- a/ansible/roles/schulcloud-server-core/templates/erwin-account-migration-job.yml.j2
+++ b/ansible/roles/schulcloud-server-core/templates/erwin-account-migration-job.yml.j2
@@ -1,0 +1,36 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: erwin-account-migration-job
+  namespace: {{ NAMESPACE }}
+  labels:
+    app: erwin-account-migration
+spec:
+  template:
+    metadata:
+      labels:
+        app: erwin-account-migration
+    spec:
+      containers:
+      - name: erwin-account-migration
+        image: {{ SCHULCLOUD_SERVER_IMAGE }}:{{ SCHULCLOUD_SERVER_IMAGE_TAG }}
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: NEST_LOG_LEVEL
+          value: "debug"
+        envFrom:
+        - configMapRef:
+            name: api-configmap
+        - secretRef:
+            name: api-secret
+        command: ['/bin/sh','-c']
+        args: ['npm run nest:start:console -- idm migrate --verbose']
+        resources:
+          limits:
+            cpu: {{ API_CPU_LIMITS|default("2000m", true) }}
+            memory: {{ API_MEMORY_LIMITS|default("2Gi", true) }}
+          requests:
+            cpu: {{ API_CPU_REQUESTS|default("100m", true) }}
+            memory: {{ API_MEMORY_REQUESTS|default("150Mi", true) }}
+      restartPolicy: Never
+  backoffLimit: 3


### PR DESCRIPTION
# Description
Added a kubernetes job to migrate (copy) the accounts from the MongoDB accounts collection to erwin-idm (keycloak) when `ERWINIDM_ACCOUNT_MIGRATION` is set to true in dof_app_deploy.

## Links to Tickets or other pull requests
Ticket: EW-129
Other PR: https://github.com/hpi-schul-cloud/dof_app_deploy/pull/525

## Changes
Added a `erwin-account-migration-job` and two ansible tasks, one which removes any old job and one which creates the job if `ERWINIDM_ACCOUNT_MIGRATION` is set to true.

## Deployment
`ERWINIDM_ACCOUNT_MIGRATION` is set to true for production in the other PR which causes the job to be created for all four production instances on the next rollout after merge.

## Approval for review
- [x] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
