### PR TITLE
N21-1194 Fix toolName duplication

### DIFF
--- a/apps/server/src/modules/tool/common/service/common-tool-validation.service.ts
+++ b/apps/server/src/modules/tool/common/service/common-tool-validation.service.ts
@@ -42,7 +42,7 @@ export class CommonToolValidationService {
 		}
 	}
 
-	public checkCustomParameterEntries(loadedExternalTool: ExternalTool, validatableTool: ValidatableTool) {
+	public checkCustomParameterEntries(loadedExternalTool: ExternalTool, validatableTool: ValidatableTool): void {
 		if (loadedExternalTool.parameters) {
 			for (const param of loadedExternalTool.parameters) {
 				this.checkScopeAndValidateParameter(validatableTool, param);

--- a/apps/server/src/modules/tool/context-external-tool/service/context-external-tool-validation.service.spec.ts
+++ b/apps/server/src/modules/tool/context-external-tool/service/context-external-tool-validation.service.spec.ts
@@ -1,8 +1,8 @@
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { ValidationError } from '@mikro-orm/core';
 import { UnprocessableEntityException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { contextExternalToolFactory, externalToolFactory } from '@shared/testing';
-import { ValidationError } from '@mikro-orm/core';
 import { CommonToolValidationService } from '../../common/service';
 import { ExternalTool } from '../../external-tool/domain';
 import { ExternalToolService } from '../../external-tool/service';
@@ -160,6 +160,40 @@ describe('ContextExternalToolValidationService', () => {
 					const { contextExternalTool1 } = setup();
 
 					const func = () => service.validate(contextExternalTool1);
+
+					await expect(func()).rejects.toThrowError(
+						new ValidationError(
+							'tool_with_name_exists: A tool with the same name is already assigned to this course. Tool names must be unique within a course.'
+						)
+					);
+				});
+			});
+
+			describe('when the displayName equals a tool name of external tool', () => {
+				const setup = () => {
+					const externalTool: ExternalTool = externalToolFactory.buildWithId({ name: 'TestTool' });
+					const changedContexExternalTool: ContextExternalTool = contextExternalToolFactory.buildWithId({
+						displayName: 'TestTool',
+					});
+					const existingContexExternalTool: ContextExternalTool = contextExternalToolFactory.buildWithId({
+						displayName: undefined,
+					});
+
+					externalToolService.findExternalToolById.mockResolvedValue(externalTool);
+					contextExternalToolService.findContextExternalTools.mockResolvedValue([
+						changedContexExternalTool,
+						existingContexExternalTool,
+					]);
+
+					return {
+						changedContexExternalTool,
+					};
+				};
+
+				it('should throw ValidationError', async () => {
+					const { changedContexExternalTool } = setup();
+
+					const func = () => service.validate(changedContexExternalTool);
 
 					await expect(func()).rejects.toThrowError(
 						new ValidationError(


### PR DESCRIPTION
Fixes duplications between context external tool display name and the external tool name

# Description
<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the begining of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/N21-1194
<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review

- [x] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
