### PR TITLE
BC-5100 - pin docker/build-push-action to version 4.1.1

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build and push ${{ github.repository }}
         if: ${{ env.IMAGE_EXISTS == 0 }}
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v4.1
         with:
           context: .
           file: ./Dockerfile
@@ -93,7 +93,7 @@ jobs:
 
       - name: Build and push ${{ github.repository }} (file storage)
         if: ${{ env.IMAGE_EXISTS == 0 }}
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v4.1
         with:
           build-args: |
             BASE_IMAGE=ghcr.io/${{ github.repository }}:${{ needs.branch_meta.outputs.sha }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build and push ${{ github.repository }}
         if: ${{ env.IMAGE_EXISTS == 0 }}
-        uses: docker/build-push-action@v4.1
+        uses: docker/build-push-action@v4.1.1
         with:
           context: .
           file: ./Dockerfile
@@ -93,7 +93,7 @@ jobs:
 
       - name: Build and push ${{ github.repository }} (file storage)
         if: ${{ env.IMAGE_EXISTS == 0 }}
-        uses: docker/build-push-action@v4.1
+        uses: docker/build-push-action@v4.1.1
         with:
           build-args: |
             BASE_IMAGE=ghcr.io/${{ github.repository }}:${{ needs.branch_meta.outputs.sha }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -39,7 +39,7 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Build and push ${{ github.repository }}
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v4.1.1
         with:
           context: .
           file: ./Dockerfile
@@ -59,7 +59,7 @@ jobs:
           labels: |
             org.opencontainers.image.title=schulcloud-file-storage
       - name: Build and push ${{ github.repository }} (file-storage)
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v4.1.1
         with:
           build-args: |
             BASE_IMAGE=quay.io/schulcloudverbund/schulcloud-server:${{ github.ref_name }}


### PR DESCRIPTION
# Description
the current version 4.2.0 for the github action docker/build-push-action who is pulled if we use as version set v4 hass an issue with our metadata json so we must pin it to version 4.1.1 for now

## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/BC-5100
hpi-schul-cloud/superhero-dashboard#229
hpi-schul-cloud/antivirus_check_service#41
hpi-schul-cloud/version-aggregator#10
hpi-schul-cloud/h5p-staticfiles-server#3
hpi-schul-cloud/schulcloud-client#3299
hpi-schul-cloud/nuxt-client#2795
hpi-schul-cloud/schulcloud-calendar#141

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review

- [x] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
