### PR TITLE
EW-622: Refactoring of Keycloak "clean" nest job

### DIFF
--- a/apps/server/src/shared/infra/identity-management/keycloak-configuration/service/keycloak-seed.service.integration.spec.ts
+++ b/apps/server/src/shared/infra/identity-management/keycloak-configuration/service/keycloak-seed.service.integration.spec.ts
@@ -81,7 +81,7 @@ describe('KeycloakSeedService Integration', () => {
 
 	// Execute this test for a test run against a running Keycloak instance
 	describe('clean', () => {
-		describe('Given all users except admin user are able to delete', () => {
+		describe('Given all users are able to delete', () => {
 			it('should delete all users in the IDM', async () => {
 				if (!isKeycloakAvailable) return;
 				const deletedUsers = await keycloakSeedService.clean(500);

--- a/apps/server/src/shared/infra/identity-management/keycloak-configuration/service/keycloak-seed.service.integration.spec.ts
+++ b/apps/server/src/shared/infra/identity-management/keycloak-configuration/service/keycloak-seed.service.integration.spec.ts
@@ -1,0 +1,92 @@
+import KeycloakAdminClient from '@keycloak/keycloak-admin-client';
+import { faker } from '@faker-js/faker';
+import { ConfigModule } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { MongoMemoryDatabaseModule } from '@shared/infra/database';
+import { LoggerModule } from '@src/core/logger';
+import { v1 } from 'uuid';
+import { KeycloakAdministrationService } from '../../keycloak-administration/service/keycloak-administration.service';
+import { KeycloakConfigurationModule } from '../keycloak-configuration.module';
+import { KeycloakSeedService } from './keycloak-seed.service';
+
+describe('KeycloakSeedService Integration', () => {
+	let module: TestingModule;
+	let keycloak: KeycloakAdminClient;
+	let keycloakSeedService: KeycloakSeedService;
+	let keycloakAdministrationService: KeycloakAdministrationService;
+	let isKeycloakAvailable = false;
+	let numberOfIdmUsers = 1009;
+
+	const testRealm = `test-realm-${v1().toString()}`;
+
+	const createIdmUser = async (index: number): Promise<void> => {
+		const firstName = faker.person.firstName();
+		const lastName = faker.person.lastName();
+		await keycloak.users.create({
+			username: `${index}.${lastName}@sp-sh.de`,
+			firstName,
+			lastName,
+			email: `${index}.${lastName}@sp-sh.de`,
+		});
+	};
+
+	beforeAll(async () => {
+		module = await Test.createTestingModule({
+			imports: [
+				KeycloakConfigurationModule,
+				LoggerModule,
+				MongoMemoryDatabaseModule.forRoot(),
+				ConfigModule.forRoot({
+					isGlobal: true,
+					ignoreEnvFile: true,
+					ignoreEnvVars: true,
+					validate: () => {
+						return {
+							FEATURE_IDENTITY_MANAGEMENT_STORE_ENABLED: true,
+						};
+					},
+				}),
+			],
+			providers: [],
+		}).compile();
+		keycloakAdministrationService = module.get(KeycloakAdministrationService);
+		isKeycloakAvailable = await keycloakAdministrationService.testKcConnection();
+		if (isKeycloakAvailable) {
+			keycloak = await keycloakAdministrationService.callKcAdminClient();
+		}
+		keycloakSeedService = module.get(KeycloakSeedService);
+	});
+
+	afterAll(async () => {
+		await module.close();
+	});
+
+	beforeEach(async () => {
+		if (isKeycloakAvailable) {
+			await keycloak.realms.create({ realm: testRealm, enabled: true });
+			keycloak.setConfig({ realmName: testRealm });
+			let i = 1;
+			for (i = 1; i <= numberOfIdmUsers; i += 1) {
+				// eslint-disable-next-line no-await-in-loop
+				await createIdmUser(i);
+			}
+		}
+	}, 60000);
+
+	afterEach(async () => {
+		if (isKeycloakAvailable) {
+			await keycloak.realms.del({ realm: testRealm });
+		}
+	});
+
+	// Execute this test for a test run against a running Keycloak instance
+	describe('clean', () => {
+		describe('Given all users except admin user are able to delete', () => {
+			it('should delete all users in the IDM', async () => {
+				if (!isKeycloakAvailable) return;
+				const deletedUsers = await keycloakSeedService.clean(500);
+				expect(deletedUsers).toBe(numberOfIdmUsers);
+			}, 60000);
+		});
+	});
+});

--- a/apps/server/src/shared/infra/identity-management/keycloak-configuration/service/keycloak-seed.service.spec.ts
+++ b/apps/server/src/shared/infra/identity-management/keycloak-configuration/service/keycloak-seed.service.spec.ts
@@ -231,18 +231,14 @@ describe('KeycloakSeedService', () => {
 			const result = await serviceUnderTest.clean();
 			expect(result).toBeGreaterThan(0);
 		});
-		it(
-			'should clean all users, but the admin',
-			async () => {
-				const deleteSpy = jest.spyOn(kcApiUsersMock, 'del');
-				await serviceUnderTest.clean();
-				users.forEach((user) => {
-					expect(deleteSpy).toHaveBeenCalledWith(expect.objectContaining({ id: user.id }));
-				});
-				expect(deleteSpy).not.toHaveBeenCalledWith(expect.objectContaining({ id: adminUser.id }));
-			},
-			10 * 60000
-		);
+		it('should clean all users, but the admin', async () => {
+			const deleteSpy = jest.spyOn(kcApiUsersMock, 'del');
+			await serviceUnderTest.clean();
+			users.forEach((user) => {
+				expect(deleteSpy).toHaveBeenCalledWith(expect.objectContaining({ id: user.id }));
+			});
+			expect(deleteSpy).not.toHaveBeenCalledWith(expect.objectContaining({ id: adminUser.id }));
+		});
 	});
 
 	describe('seed', () => {

--- a/apps/server/src/shared/infra/identity-management/keycloak-configuration/service/keycloak-seed.service.ts
+++ b/apps/server/src/shared/infra/identity-management/keycloak-configuration/service/keycloak-seed.service.ts
@@ -48,7 +48,7 @@ export class KeycloakSeedService {
 			for (const user of users) {
 				// eslint-disable-next-line no-await-in-loop
 				kc = await this.kcAdmin.callKcAdminClient();
-				console.log(`try to delete user ${user.id as string}`);
+				// console.log(`try to delete user ${user.id as string}`);
 				// eslint-disable-next-line no-await-in-loop
 				await kc.users.del({
 					// can not be undefined, see filter above

--- a/apps/server/src/shared/infra/identity-management/keycloak-configuration/service/keycloak-seed.service.ts
+++ b/apps/server/src/shared/infra/identity-management/keycloak-configuration/service/keycloak-seed.service.ts
@@ -37,26 +37,24 @@ export class KeycloakSeedService {
 		let deletedUsers = 0;
 		const adminUser = this.kcAdmin.getAdminUser();
 		let kc = await this.kcAdmin.callKcAdminClient();
-		console.log(`Starting to delete users...`);
+		this.logger.log(`Starting to delete users...`);
 		while (foundUsers > 0) {
 			// eslint-disable-next-line no-await-in-loop
 			kc = await this.kcAdmin.callKcAdminClient();
 			// eslint-disable-next-line no-await-in-loop
 			const users = (await kc.users.find({ max: pagination })).filter((user) => user.username !== adminUser);
 			foundUsers = users.length;
-			console.log(`Length of foundUsers: ${foundUsers}`);
+			this.logger.log(`Length of foundUsers: ${foundUsers}`);
 			for (const user of users) {
 				// eslint-disable-next-line no-await-in-loop
 				kc = await this.kcAdmin.callKcAdminClient();
-				// console.log(`try to delete user ${user.id as string}`);
 				// eslint-disable-next-line no-await-in-loop
 				await kc.users.del({
-					// can not be undefined, see filter above
 					id: user.id ?? '',
 				});
 			}
 			deletedUsers += foundUsers;
-			console.log(`...deleted ${deletedUsers} users so far.`);
+			this.logger.log(`...deleted ${deletedUsers} users so far.`);
 		}
 		return deletedUsers;
 	}

--- a/apps/server/src/shared/infra/identity-management/keycloak-configuration/uc/keycloak-configuration.uc.ts
+++ b/apps/server/src/shared/infra/identity-management/keycloak-configuration/uc/keycloak-configuration.uc.ts
@@ -17,8 +17,8 @@ export class KeycloakConfigurationUc {
 		return this.kcAdmin.testKcConnection();
 	}
 
-	public async clean(): Promise<number> {
-		return this.keycloakSeedService.clean();
+	public async clean(pagination?: number): Promise<number> {
+		return this.keycloakSeedService.clean(pagination);
 	}
 
 	public async seed(): Promise<number> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,6 +132,7 @@
 			},
 			"devDependencies": {
 				"@aws-sdk/client-s3": "^3.352.0",
+				"@faker-js/faker": "^8.0.2",
 				"@golevelup/ts-jest": "^0.3.4",
 				"@jest-mock/express": "^1.4.5",
 				"@nestjs/cli": "^10.1.17",
@@ -2909,6 +2910,22 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@faker-js/faker": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.1.0.tgz",
+			"integrity": "sha512-38DT60rumHfBYynif3lmtxMqMqmsOQIxQgEuPZxCk2yUYN0eqWpTACgxi0VpidvsJB8CRxCpvP7B3anK85FjtQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fakerjs"
+				}
+			],
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+				"npm": ">=6.14.13"
 			}
 		},
 		"node_modules/@feathers-plus/batch-loader": {
@@ -26657,6 +26674,12 @@
 					"dev": true
 				}
 			}
+		},
+		"@faker-js/faker": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.1.0.tgz",
+			"integrity": "sha512-38DT60rumHfBYynif3lmtxMqMqmsOQIxQgEuPZxCk2yUYN0eqWpTACgxi0VpidvsJB8CRxCpvP7B3anK85FjtQ==",
+			"dev": true
 		},
 		"@feathers-plus/batch-loader": {
 			"version": "0.3.6",

--- a/package.json
+++ b/package.json
@@ -214,6 +214,7 @@
 	},
 	"devDependencies": {
 		"@aws-sdk/client-s3": "^3.352.0",
+		"@faker-js/faker": "^8.0.2",
 		"@golevelup/ts-jest": "^0.3.4",
 		"@jest-mock/express": "^1.4.5",
 		"@nestjs/cli": "^10.1.17",


### PR DESCRIPTION
# Description
Refactors the nest job "clean" to be used in production, to delete all users of keycloak realm.
The goal is, to be able to remove all keycloak users to run the initial migration job between MongoDB and PostgresDB again without having user data "leftovers" from any former run afterwards. 

## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/EW-622


## Changes
There is no limitation by the Keycloak admin client find request anymore how many users can be deleted per run. The script will run until no users (except the admin user) exists in the realm anymore.
An optional "pagination" parameter was introduced, to set the amount of users, which will be returned by the find request. This will determine the bulk of users to be deleted per each deletion loop.  

## Approval for review

- [ ] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
