### PR TITLE
EW-553: Export description of etherpad content as title of weblink.

### DIFF
--- a/apps/server/src/modules/learnroom/service/common-cartridge-export.service.ts
+++ b/apps/server/src/modules/learnroom/service/common-cartridge-export.service.ts
@@ -115,8 +115,18 @@ export class CommonCartridgeExportService {
 
 		if (content.component === ComponentType.ETHERPAD) {
 			return version === CommonCartridgeVersion.V_1_3_0
-				? { ...commonProps, type: CommonCartridgeResourceType.WEB_LINK_V3, url: content.content.url }
-				: { ...commonProps, type: CommonCartridgeResourceType.WEB_LINK_V1, url: content.content.url };
+				? {
+						...commonProps,
+						type: CommonCartridgeResourceType.WEB_LINK_V3,
+						url: content.content.url,
+						title: content.content.description,
+				  }
+				: {
+						...commonProps,
+						type: CommonCartridgeResourceType.WEB_LINK_V1,
+						url: content.content.url,
+						title: content.content.description,
+				  };
 		}
 
 		return undefined;


### PR DESCRIPTION
# Description
Add the description of an etherpad content as the title of a weblink during export.
## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/EW-553

## Approval for review
- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

