### PR TITLE
BC-5546 - Split ingress for Domains 

### DIFF
--- a/ansible/roles/schulcloud-server-core/tasks/main.yml
+++ b/ansible/roles/schulcloud-server-core/tasks/main.yml
@@ -58,6 +58,12 @@
       kubeconfig: ~/.kube/config
       namespace: "{{ NAMESPACE }}"
       template: deployment.yml.j2
+      
+  - name: Ingress
+    kubernetes.core.k8s:
+      kubeconfig: ~/.kube/config
+      namespace: "{{ NAMESPACE }}"
+      template: ingress.yml.j2
 
   - name: FileStorageDeployment
     kubernetes.core.k8s:
@@ -65,11 +71,30 @@
       namespace: "{{ NAMESPACE }}"
       template: api-files-deployment.yml.j2
 
+  - name: FileStorageDeployment
+    kubernetes.core.k8s:
+      kubeconfig: ~/.kube/config
+      namespace: "{{ NAMESPACE }}"
+      template: api-files-deployment.yml.j2
+
+  - name: File Storage Ingress
+    kubernetes.core.k8s:
+      kubeconfig: ~/.kube/config
+      namespace: "{{ NAMESPACE }}"
+      template: api-files-ingress.yml.j2
+
   - name: FwuLearningContentsDeployment
     kubernetes.core.k8s:
       kubeconfig: ~/.kube/config
       namespace: "{{ NAMESPACE }}"
       template: api-fwu-deployment.yml.j2
+    when: FEATURE_FWU_CONTENT_ENABLED is defined and FEATURE_FWU_CONTENT_ENABLED|bool
+
+  - name: Fwu Learning Contents Ingress
+    kubernetes.core.k8s:
+      kubeconfig: ~/.kube/config
+      namespace: "{{ NAMESPACE }}"
+      template: api-fwu-ingress.yml.j2
     when: FEATURE_FWU_CONTENT_ENABLED is defined and FEATURE_FWU_CONTENT_ENABLED|bool
 
   - name: Delete Files CronJob

--- a/ansible/roles/schulcloud-server-core/tasks/main.yml
+++ b/ansible/roles/schulcloud-server-core/tasks/main.yml
@@ -64,6 +64,7 @@
       kubeconfig: ~/.kube/config
       namespace: "{{ NAMESPACE }}"
       template: ingress.yml.j2
+      apply: yes
 
   - name: FileStorageDeployment
     kubernetes.core.k8s:
@@ -82,6 +83,7 @@
       kubeconfig: ~/.kube/config
       namespace: "{{ NAMESPACE }}"
       template: api-files-ingress.yml.j2
+      apply: yes
 
   - name: FwuLearningContentsDeployment
     kubernetes.core.k8s:
@@ -95,6 +97,7 @@
       kubeconfig: ~/.kube/config
       namespace: "{{ NAMESPACE }}"
       template: api-fwu-ingress.yml.j2
+      apply: yes
     when: FEATURE_FWU_CONTENT_ENABLED is defined and FEATURE_FWU_CONTENT_ENABLED|bool
 
   - name: Delete Files CronJob

--- a/ansible/roles/schulcloud-server-core/templates/api-files-ingress.yml.j2
+++ b/ansible/roles/schulcloud-server-core/templates/api-files-ingress.yml.j2
@@ -17,6 +17,14 @@ metadata:
     nginx.ingress.kubernetes.io/server-snippet: |
       client_header_buffer_size 100k;
       large_client_header_buffers 4 100k;
+{% if KEDA_NAMESPACE_ACTIVATOR_ENABLED is defined %}
+      proxy_intercept_errors on;
+      error_page 503 = @errorpages;
+
+      location @errorpages {
+        return 302 'https://activate.cd.dbildungscloud.dev/namespace?namespace={{ NAMESPACE }}&redirected-from-503=true';
+      }
+{% endif %}
 {% if CLUSTER_ISSUER is defined %}
     cert-manager.io/cluster-issuer: {{ CLUSTER_ISSUER }}
 {% endif %}

--- a/ansible/roles/schulcloud-server-core/templates/api-files-ingress.yml.j2
+++ b/ansible/roles/schulcloud-server-core/templates/api-files-ingress.yml.j2
@@ -1,0 +1,44 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ NAMESPACE }}-api-files-ingress
+  namespace: {{ NAMESPACE }}
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "{{ TLS_ENABELD|default("false") }}"
+    nginx.ingress.kubernetes.io/proxy-body-size: "{{ INGRESS_MAX_BODY_SIZE|default("2560") }}m"
+    nginx.org/client-max-body-size: "{{ INGRESS_MAX_BODY_SIZE|default("2560") }}m"
+    # The following properties added with BC-3606.
+    # The header size of the request is too big. For e.g. state and the permanent growing jwt.
+    # Nginx throws away the Location header, resulting in the 502 Bad Gateway.
+    nginx.ingress.kubernetes.io/client-header-buffer-size: 100k
+    nginx.ingress.kubernetes.io/http2-max-header-size: 96k
+    nginx.ingress.kubernetes.io/large-client-header-buffers: 4 100k
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 96k
+    nginx.ingress.kubernetes.io/server-snippet: |
+      client_header_buffer_size 100k;
+      large_client_header_buffers 4 100k;
+{% if CLUSTER_ISSUER is defined %}
+    cert-manager.io/cluster-issuer: {{ CLUSTER_ISSUER }}
+{% endif %}
+
+spec:
+  ingressClassName: nginx
+{% if CLUSTER_ISSUER is defined or (TLS_ENABELD is defined and TLS_ENABELD|bool) %}
+  tls:
+  - hosts:
+      - {{ DOMAIN }}
+{% if CLUSTER_ISSUER is defined %}
+    secretName: {{ DOMAIN }}-tls
+{% endif %}
+{% endif %}
+  rules:
+  - host: {{ DOMAIN }}
+    http:
+      paths:
+      - path: /api/v3/file/
+        backend:
+          service:
+            name: api-files-svc
+            port:
+              number: {{ PORT_FILE_SERVICE }}
+        pathType: Prefix

--- a/ansible/roles/schulcloud-server-core/templates/api-files-ingress.yml.j2
+++ b/ansible/roles/schulcloud-server-core/templates/api-files-ingress.yml.j2
@@ -14,17 +14,6 @@ metadata:
     nginx.ingress.kubernetes.io/http2-max-header-size: 96k
     nginx.ingress.kubernetes.io/large-client-header-buffers: 4 100k
     nginx.ingress.kubernetes.io/proxy-buffer-size: 96k
-    nginx.ingress.kubernetes.io/server-snippet: |
-      client_header_buffer_size 100k;
-      large_client_header_buffers 4 100k;
-{% if KEDA_NAMESPACE_ACTIVATOR_ENABLED is defined %}
-      proxy_intercept_errors on;
-      error_page 503 = @errorpages;
-
-      location @errorpages {
-        return 302 'https://activate.cd.dbildungscloud.dev/namespace?namespace={{ NAMESPACE }}&redirected-from-503=true';
-      }
-{% endif %}
 {% if CLUSTER_ISSUER is defined %}
     cert-manager.io/cluster-issuer: {{ CLUSTER_ISSUER }}
 {% endif %}

--- a/ansible/roles/schulcloud-server-core/templates/api-fwu-ingress.yml.j2
+++ b/ansible/roles/schulcloud-server-core/templates/api-fwu-ingress.yml.j2
@@ -17,6 +17,14 @@ metadata:
     nginx.ingress.kubernetes.io/server-snippet: |
       client_header_buffer_size 100k;
       large_client_header_buffers 4 100k;
+{% if KEDA_NAMESPACE_ACTIVATOR_ENABLED is defined %}
+      proxy_intercept_errors on;
+      error_page 503 = @errorpages;
+
+      location @errorpages {
+        return 302 'https://activate.cd.dbildungscloud.dev/namespace?namespace={{ NAMESPACE }}&redirected-from-503=true';
+      }
+{% endif %}
 {% if CLUSTER_ISSUER is defined %}
     cert-manager.io/cluster-issuer: {{ CLUSTER_ISSUER }}
 {% endif %}

--- a/ansible/roles/schulcloud-server-core/templates/api-fwu-ingress.yml.j2
+++ b/ansible/roles/schulcloud-server-core/templates/api-fwu-ingress.yml.j2
@@ -1,0 +1,44 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ NAMESPACE }}-api-fwu-ingress
+  namespace: {{ NAMESPACE }}
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "{{ TLS_ENABELD|default("false") }}"
+    nginx.ingress.kubernetes.io/proxy-body-size: "{{ INGRESS_MAX_BODY_SIZE|default("2560") }}m"
+    nginx.org/client-max-body-size: "{{ INGRESS_MAX_BODY_SIZE|default("2560") }}m"
+    # The following properties added with BC-3606.
+    # The header size of the request is too big. For e.g. state and the permanent growing jwt.
+    # Nginx throws away the Location header, resulting in the 502 Bad Gateway.
+    nginx.ingress.kubernetes.io/client-header-buffer-size: 100k
+    nginx.ingress.kubernetes.io/http2-max-header-size: 96k
+    nginx.ingress.kubernetes.io/large-client-header-buffers: 4 100k
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 96k
+    nginx.ingress.kubernetes.io/server-snippet: |
+      client_header_buffer_size 100k;
+      large_client_header_buffers 4 100k;
+{% if CLUSTER_ISSUER is defined %}
+    cert-manager.io/cluster-issuer: {{ CLUSTER_ISSUER }}
+{% endif %}
+
+spec:
+  ingressClassName: nginx
+{% if CLUSTER_ISSUER is defined or (TLS_ENABELD is defined and TLS_ENABELD|bool) %}
+  tls:
+  - hosts:
+      - {{ DOMAIN }}
+{% if CLUSTER_ISSUER is defined %}
+    secretName: {{ DOMAIN }}-tls
+{% endif %}
+{% endif %}
+  rules:
+  - host: {{ DOMAIN }}
+    http:
+      paths:
+      - path: /api/v3/fwu/
+        backend:
+          service:
+            name: api-fwu-svc
+            port:
+              number: {{ PORT_FWU_LEARNING_CONTENTS }}
+        pathType: Prefix

--- a/ansible/roles/schulcloud-server-core/templates/api-fwu-ingress.yml.j2
+++ b/ansible/roles/schulcloud-server-core/templates/api-fwu-ingress.yml.j2
@@ -14,17 +14,6 @@ metadata:
     nginx.ingress.kubernetes.io/http2-max-header-size: 96k
     nginx.ingress.kubernetes.io/large-client-header-buffers: 4 100k
     nginx.ingress.kubernetes.io/proxy-buffer-size: 96k
-    nginx.ingress.kubernetes.io/server-snippet: |
-      client_header_buffer_size 100k;
-      large_client_header_buffers 4 100k;
-{% if KEDA_NAMESPACE_ACTIVATOR_ENABLED is defined %}
-      proxy_intercept_errors on;
-      error_page 503 = @errorpages;
-
-      location @errorpages {
-        return 302 'https://activate.cd.dbildungscloud.dev/namespace?namespace={{ NAMESPACE }}&redirected-from-503=true';
-      }
-{% endif %}
 {% if CLUSTER_ISSUER is defined %}
     cert-manager.io/cluster-issuer: {{ CLUSTER_ISSUER }}
 {% endif %}

--- a/ansible/roles/schulcloud-server-core/templates/ingress.yml.j2
+++ b/ansible/roles/schulcloud-server-core/templates/ingress.yml.j2
@@ -1,0 +1,44 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ NAMESPACE }}-api-ingress
+  namespace: {{ NAMESPACE }}
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "{{ TLS_ENABELD|default("false") }}"
+    nginx.ingress.kubernetes.io/proxy-body-size: "{{ INGRESS_MAX_BODY_SIZE|default("2560") }}m"
+    nginx.org/client-max-body-size: "{{ INGRESS_MAX_BODY_SIZE|default("2560") }}m"
+    # The following properties added with BC-3606.
+    # The header size of the request is too big. For e.g. state and the permanent growing jwt.
+    # Nginx throws away the Location header, resulting in the 502 Bad Gateway.
+    nginx.ingress.kubernetes.io/client-header-buffer-size: 100k
+    nginx.ingress.kubernetes.io/http2-max-header-size: 96k
+    nginx.ingress.kubernetes.io/large-client-header-buffers: 4 100k
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 96k
+    nginx.ingress.kubernetes.io/server-snippet: |
+      client_header_buffer_size 100k;
+      large_client_header_buffers 4 100k;
+{% if CLUSTER_ISSUER is defined %}
+    cert-manager.io/cluster-issuer: {{ CLUSTER_ISSUER }}
+{% endif %}
+
+spec:
+  ingressClassName: nginx
+{% if CLUSTER_ISSUER is defined or (TLS_ENABELD is defined and TLS_ENABELD|bool) %}
+  tls:
+  - hosts:
+      - {{ DOMAIN }}
+{% if CLUSTER_ISSUER is defined %}
+    secretName: {{ DOMAIN }}-tls
+{% endif %}
+{% endif %}
+  rules:
+  - host: {{ DOMAIN }}
+    http:
+      paths:
+      - path: /api/v3/
+        backend:
+          service:
+            name: api-svc
+            port:
+              number: {{ PORT_SERVER }}
+        pathType: Prefix

--- a/ansible/roles/schulcloud-server-core/templates/ingress.yml.j2
+++ b/ansible/roles/schulcloud-server-core/templates/ingress.yml.j2
@@ -17,6 +17,14 @@ metadata:
     nginx.ingress.kubernetes.io/server-snippet: |
       client_header_buffer_size 100k;
       large_client_header_buffers 4 100k;
+{% if KEDA_NAMESPACE_ACTIVATOR_ENABLED is defined %}
+      proxy_intercept_errors on;
+      error_page 503 = @errorpages;
+
+      location @errorpages {
+        return 302 'https://activate.cd.dbildungscloud.dev/namespace?namespace={{ NAMESPACE }}&redirected-from-503=true';
+      }
+{% endif %}
 {% if CLUSTER_ISSUER is defined %}
     cert-manager.io/cluster-issuer: {{ CLUSTER_ISSUER }}
 {% endif %}

--- a/ansible/roles/schulcloud-server-core/templates/ingress.yml.j2
+++ b/ansible/roles/schulcloud-server-core/templates/ingress.yml.j2
@@ -14,17 +14,6 @@ metadata:
     nginx.ingress.kubernetes.io/http2-max-header-size: 96k
     nginx.ingress.kubernetes.io/large-client-header-buffers: 4 100k
     nginx.ingress.kubernetes.io/proxy-buffer-size: 96k
-    nginx.ingress.kubernetes.io/server-snippet: |
-      client_header_buffer_size 100k;
-      large_client_header_buffers 4 100k;
-{% if KEDA_NAMESPACE_ACTIVATOR_ENABLED is defined %}
-      proxy_intercept_errors on;
-      error_page 503 = @errorpages;
-
-      location @errorpages {
-        return 302 'https://activate.cd.dbildungscloud.dev/namespace?namespace={{ NAMESPACE }}&redirected-from-503=true';
-      }
-{% endif %}
 {% if CLUSTER_ISSUER is defined %}
     cert-manager.io/cluster-issuer: {{ CLUSTER_ISSUER }}
 {% endif %}

--- a/ansible/roles/schulcloud-server-h5p/tasks/main.yml
+++ b/ansible/roles/schulcloud-server-h5p/tasks/main.yml
@@ -17,5 +17,6 @@
       kubeconfig: ~/.kube/config
       namespace: "{{ NAMESPACE }}"
       template: api-h5p-ingress.yml.j2
+      apply: yes
     when: WITH_H5P_EDITOR is defined and WITH_H5P_EDITOR|bool
     

--- a/ansible/roles/schulcloud-server-h5p/tasks/main.yml
+++ b/ansible/roles/schulcloud-server-h5p/tasks/main.yml
@@ -12,3 +12,10 @@
       template: api-h5p-deployment.yml.j2
     when: WITH_H5P_EDITOR is defined and WITH_H5P_EDITOR|bool
     
+  - name: H5p Editor Ingress
+    kubernetes.core.k8s:
+      kubeconfig: ~/.kube/config
+      namespace: "{{ NAMESPACE }}"
+      template: api-h5p-ingress.yml.j2
+    when: WITH_H5P_EDITOR is defined and WITH_H5P_EDITOR|bool
+    

--- a/ansible/roles/schulcloud-server-h5p/templates/api-h5p-ingress.yml.j2
+++ b/ansible/roles/schulcloud-server-h5p/templates/api-h5p-ingress.yml.j2
@@ -17,6 +17,14 @@ metadata:
     nginx.ingress.kubernetes.io/server-snippet: |
       client_header_buffer_size 100k;
       large_client_header_buffers 4 100k;
+{% if KEDA_NAMESPACE_ACTIVATOR_ENABLED is defined %}
+      proxy_intercept_errors on;
+      error_page 503 = @errorpages;
+
+      location @errorpages {
+        return 302 'https://activate.cd.dbildungscloud.dev/namespace?namespace={{ NAMESPACE }}&redirected-from-503=true';
+      }
+{% endif %}
 {% if CLUSTER_ISSUER is defined %}
     cert-manager.io/cluster-issuer: {{ CLUSTER_ISSUER }}
 {% endif %}

--- a/ansible/roles/schulcloud-server-h5p/templates/api-h5p-ingress.yml.j2
+++ b/ansible/roles/schulcloud-server-h5p/templates/api-h5p-ingress.yml.j2
@@ -1,0 +1,44 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ NAMESPACE }}-api-h5p-ingress
+  namespace: {{ NAMESPACE }}
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "{{ TLS_ENABELD|default("false") }}"
+    nginx.ingress.kubernetes.io/proxy-body-size: "{{ INGRESS_MAX_BODY_SIZE|default("2560") }}m"
+    nginx.org/client-max-body-size: "{{ INGRESS_MAX_BODY_SIZE|default("2560") }}m"
+    # The following properties added with BC-3606.
+    # The header size of the request is too big. For e.g. state and the permanent growing jwt.
+    # Nginx throws away the Location header, resulting in the 502 Bad Gateway.
+    nginx.ingress.kubernetes.io/client-header-buffer-size: 100k
+    nginx.ingress.kubernetes.io/http2-max-header-size: 96k
+    nginx.ingress.kubernetes.io/large-client-header-buffers: 4 100k
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 96k
+    nginx.ingress.kubernetes.io/server-snippet: |
+      client_header_buffer_size 100k;
+      large_client_header_buffers 4 100k;
+{% if CLUSTER_ISSUER is defined %}
+    cert-manager.io/cluster-issuer: {{ CLUSTER_ISSUER }}
+{% endif %}
+
+spec:
+  ingressClassName: nginx
+{% if CLUSTER_ISSUER is defined or (TLS_ENABELD is defined and TLS_ENABELD|bool) %}
+  tls:
+  - hosts:
+      - {{ DOMAIN }}
+{% if CLUSTER_ISSUER is defined %}
+    secretName: {{ DOMAIN }}-tls
+{% endif %}
+{% endif %}
+  rules:
+  - host: {{ DOMAIN }}
+    http:
+      paths:
+      - path: /api/v3/h5p-editor/
+        backend:
+          service:
+            name: api-h5p-svc
+            port:
+              number: 4448
+        pathType: Prefix

--- a/ansible/roles/schulcloud-server-h5p/templates/api-h5p-ingress.yml.j2
+++ b/ansible/roles/schulcloud-server-h5p/templates/api-h5p-ingress.yml.j2
@@ -14,17 +14,6 @@ metadata:
     nginx.ingress.kubernetes.io/http2-max-header-size: 96k
     nginx.ingress.kubernetes.io/large-client-header-buffers: 4 100k
     nginx.ingress.kubernetes.io/proxy-buffer-size: 96k
-    nginx.ingress.kubernetes.io/server-snippet: |
-      client_header_buffer_size 100k;
-      large_client_header_buffers 4 100k;
-{% if KEDA_NAMESPACE_ACTIVATOR_ENABLED is defined %}
-      proxy_intercept_errors on;
-      error_page 503 = @errorpages;
-
-      location @errorpages {
-        return 302 'https://activate.cd.dbildungscloud.dev/namespace?namespace={{ NAMESPACE }}&redirected-from-503=true';
-      }
-{% endif %}
 {% if CLUSTER_ISSUER is defined %}
     cert-manager.io/cluster-issuer: {{ CLUSTER_ISSUER }}
 {% endif %}


### PR DESCRIPTION
# Description
Separate the Server Ingress to the Server Repo and for each service in own.
With the current version of nginx ingress is it possible to have more igresses with different resources for one domain.

## Links to Tickets or other pull requests
hpi-schul-cloud/dof_app_deploy#678
https://ticketsystem.dbildungscloud.de/browse/BC-5546

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review

- [x] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
