### PR TITLE
N21-1187 Fix optional External Tool parameter with regex

### DIFF
--- a/apps/server/src/modules/tool/common/service/common-tool-validation.service.spec.ts
+++ b/apps/server/src/modules/tool/common/service/common-tool-validation.service.spec.ts
@@ -597,6 +597,7 @@ describe('CommonToolValidationService', () => {
 				const setup = () => {
 					const undefinedRegex: CustomParameter = customParameterFactory.build({
 						name: 'undefinedRegex',
+						isOptional: false,
 						scope: CustomParameterScope.SCHOOL,
 						type: CustomParameterType.STRING,
 						regex: undefined,
@@ -629,6 +630,7 @@ describe('CommonToolValidationService', () => {
 				const setup = () => {
 					const validRegex: CustomParameter = customParameterFactory.build({
 						name: 'validRegex',
+						isOptional: false,
 						scope: CustomParameterScope.SCHOOL,
 						type: CustomParameterType.STRING,
 						regex: '[x]',
@@ -661,6 +663,7 @@ describe('CommonToolValidationService', () => {
 				const setup = () => {
 					const validRegex: CustomParameter = customParameterFactory.build({
 						name: 'validRegex',
+						isOptional: false,
 						scope: CustomParameterScope.SCHOOL,
 						type: CustomParameterType.STRING,
 						regex: '[x]',
@@ -686,6 +689,39 @@ describe('CommonToolValidationService', () => {
 					const func = () => service.checkCustomParameterEntries(externalTool, schoolExternalTool);
 
 					expect(func).toThrowError('tool_param_value_regex');
+				});
+			});
+
+			describe('when parameter is optional and a regex is given, but the param value is undefined', () => {
+				const setup = () => {
+					const optionalRegex: CustomParameter = customParameterFactory.build({
+						name: 'optionalRegex',
+						isOptional: true,
+						scope: CustomParameterScope.SCHOOL,
+						type: CustomParameterType.STRING,
+						regex: '[x]',
+					});
+					const { externalTool, schoolExternalTool } = createTools(
+						{
+							parameters: [optionalRegex],
+						},
+						{
+							parameters: [{ name: 'optionalRegex', value: undefined }],
+						}
+					);
+
+					return {
+						externalTool,
+						schoolExternalTool,
+					};
+				};
+
+				it('should return without error', () => {
+					const { externalTool, schoolExternalTool } = setup();
+
+					const func = () => service.checkCustomParameterEntries(externalTool, schoolExternalTool);
+
+					expect(func).not.toThrowError('tool_param_value_regex');
 				});
 			});
 		});

--- a/apps/server/src/modules/tool/common/service/common-tool-validation.service.ts
+++ b/apps/server/src/modules/tool/common/service/common-tool-validation.service.ts
@@ -87,7 +87,7 @@ export class CommonToolValidationService {
 	}
 
 	private checkParameterRegex(foundEntry: CustomParameterEntry, param: CustomParameter): void {
-		if (param.regex && !new RegExp(param.regex).test(foundEntry.value ?? '')) {
+		if (foundEntry.value !== undefined && param.regex && !new RegExp(param.regex).test(foundEntry.value ?? '')) {
 			throw new ValidationError(
 				`tool_param_value_regex: The given entry for the parameter with name ${foundEntry.name} does not fit the regex.`
 			);

--- a/apps/server/src/modules/tool/external-tool/service/external-tool-validation.service.ts
+++ b/apps/server/src/modules/tool/external-tool/service/external-tool-validation.service.ts
@@ -1,6 +1,5 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { ValidationError } from '@shared/common';
-import { IToolFeatures, ToolFeatures } from '../../tool-config';
 import { ExternalTool } from '../domain';
 import { ExternalToolLogoService } from './external-tool-logo.service';
 import { ExternalToolParameterValidationService } from './external-tool-parameter-validation.service';
@@ -11,7 +10,6 @@ export class ExternalToolValidationService {
 	constructor(
 		private readonly externalToolService: ExternalToolService,
 		private readonly externalToolParameterValidationService: ExternalToolParameterValidationService,
-		@Inject(ToolFeatures) private readonly toolFeatures: IToolFeatures,
 		private readonly externalToolLogoService: ExternalToolLogoService
 	) {}
 


### PR DESCRIPTION
# Description
<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the begining of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/N21-1187
<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review

- [x] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
