### PR TITLE
EW-742: AccountRepo refactoring

### DIFF
--- a/apps/server/src/modules/account/domain/account.ts
+++ b/apps/server/src/modules/account/domain/account.ts
@@ -66,16 +66,32 @@ export class Account extends DomainObject<AccountProps> {
 		return this.props.token;
 	}
 
+	public set token(token: string | undefined) {
+		this.props.token = token;
+	}
+
 	public get credentialHash(): string | undefined {
 		return this.props.credentialHash;
+	}
+
+	public set credentialHash(credentialHash: string | undefined) {
+		this.props.credentialHash = credentialHash;
 	}
 
 	public get lasttriedFailedLogin(): Date | undefined {
 		return this.props.lasttriedFailedLogin;
 	}
 
+	public set lasttriedFailedLogin(lasttriedFailedLogin: Date | undefined) {
+		this.props.lasttriedFailedLogin = lasttriedFailedLogin;
+	}
+
 	public get expiresAt(): Date | undefined {
 		return this.props.expiresAt;
+	}
+
+	public set expiresAt(expiresAt: Date | undefined) {
+		this.props.expiresAt = expiresAt;
 	}
 
 	public get activated(): boolean | undefined {

--- a/apps/server/src/modules/account/repo/account.repo.ts
+++ b/apps/server/src/modules/account/repo/account.repo.ts
@@ -1,15 +1,41 @@
-import { AnyEntity, EntityName, Primary } from '@mikro-orm/core';
-import { ObjectId } from '@mikro-orm/mongodb';
+import { AnyEntity, EntityName, FilterQuery, Primary } from '@mikro-orm/core';
+import { EntityManager, ObjectId } from '@mikro-orm/mongodb';
 import { Injectable } from '@nestjs/common';
 import { SortOrder } from '@shared/domain/interface';
 import { Counted, EntityId } from '@shared/domain/types';
-import { BaseRepo } from '@shared/repo/base.repo';
 import { AccountEntity } from '../entity/account.entity';
+import { AccountDoToEntityMapper } from './mapper/account-do-to-entity.mapper';
+import { Account } from '../domain/account';
+import { AccountEntityToDoMapper } from './mapper';
 
 @Injectable()
-export class AccountRepo extends BaseRepo<AccountEntity> {
+export class AccountRepo {
+	constructor(private readonly em: EntityManager) {}
+
 	get entityName() {
 		return AccountEntity;
+	}
+
+	public async save(account: Account): Promise<Account> {
+		const saveEntity = AccountDoToEntityMapper.mapToEntity(account);
+		const existing = await this.em.findOne(AccountEntity, { id: account.id });
+
+		let saved: AccountEntity;
+		if (existing) {
+			saved = this.em.assign(existing, saveEntity);
+		} else {
+			this.em.persist(saveEntity);
+			saved = saveEntity;
+		}
+		await this.flush();
+
+		return AccountEntityToDoMapper.mapToDo(saved);
+	}
+
+	public async findById(id: EntityId | ObjectId): Promise<Account> {
+		const entity = await this.em.findOneOrFail(this.entityName, id as FilterQuery<AccountEntity>);
+
+		return AccountEntityToDoMapper.mapToDo(entity);
 	}
 
 	/**
@@ -17,69 +43,92 @@ export class AccountRepo extends BaseRepo<AccountEntity> {
 	 * @param userId the user id
 	 */
 	// TODO: here only EntityIds should arrive => hard to determine because this is used by feathers/js part
-	async findByUserId(userId: EntityId | ObjectId): Promise<AccountEntity | null> {
+	public async findByUserId(userId: EntityId | ObjectId): Promise<Account | null> {
 		// TODO: you can use userId directly, without constructing an objectId => AccountEntity still uses ObjectId
-		return this._em.findOne(AccountEntity, { userId: new ObjectId(userId) });
+		const entity = await this.em.findOne(AccountEntity, { userId: new ObjectId(userId) });
+
+		if (!entity) {
+			return null;
+		}
+
+		return AccountEntityToDoMapper.mapToDo(entity);
 	}
 
-	async findMultipleByUserId(userIds: EntityId[] | ObjectId[]): Promise<AccountEntity[]> {
+	public async findMultipleByUserId(userIds: EntityId[] | ObjectId[]): Promise<Account[]> {
 		const objectIds = userIds.map((id: EntityId | ObjectId) => new ObjectId(id));
-		return this._em.find(AccountEntity, { userId: objectIds });
+		const entities = await this.em.find(AccountEntity, { userId: objectIds });
+
+		return AccountEntityToDoMapper.mapEntitiesToDos(entities);
 	}
 
-	async findByUserIdOrFail(userId: EntityId | ObjectId): Promise<AccountEntity> {
-		return this._em.findOneOrFail(AccountEntity, { userId: new ObjectId(userId) });
+	public async findByUserIdOrFail(userId: EntityId | ObjectId): Promise<Account> {
+		const entity = await this.em.findOneOrFail(AccountEntity, { userId: new ObjectId(userId) });
+
+		return AccountEntityToDoMapper.mapToDo(entity);
 	}
 
-	async findByUsernameAndSystemId(username: string, systemId: EntityId | ObjectId): Promise<AccountEntity | null> {
-		return this._em.findOne(AccountEntity, { username, systemId: new ObjectId(systemId) });
+	public async findByUsernameAndSystemId(username: string, systemId: EntityId | ObjectId): Promise<Account | null> {
+		const entity = await this.em.findOne(AccountEntity, { username, systemId: new ObjectId(systemId) });
+
+		if (!entity) {
+			return null;
+		}
+
+		return AccountEntityToDoMapper.mapToDo(entity);
 	}
 
 	getObjectReference<Entity extends AnyEntity<Entity>>(
 		entityName: EntityName<Entity>,
 		id: Primary<Entity> | Primary<Entity>[]
 	): Entity {
-		return this._em.getReference(entityName, id);
+		return this.em.getReference(entityName, id);
 	}
 
-	saveWithoutFlush(account: AccountEntity): void {
-		this._em.persist(account);
+	public async saveWithoutFlush(account: Account): Promise<void> {
+		const saveEntity = AccountDoToEntityMapper.mapToEntity(account);
+		const existing = await this.em.findOne(AccountEntity, { id: account.id });
+
+		if (existing) {
+			this.em.assign(existing, saveEntity);
+		} else {
+			this.em.persist(saveEntity);
+		}
 	}
 
-	async flush(): Promise<void> {
-		await this._em.flush();
+	public async flush(): Promise<void> {
+		await this.em.flush();
 	}
 
-	async searchByUsernameExactMatch(username: string, skip = 0, limit = 1): Promise<Counted<AccountEntity[]>> {
+	public async searchByUsernameExactMatch(username: string, skip = 0, limit = 1): Promise<Counted<Account[]>> {
 		return this.searchByUsername(username, skip, limit, true);
 	}
 
-	async searchByUsernamePartialMatch(username: string, skip = 0, limit = 10): Promise<Counted<AccountEntity[]>> {
+	public async searchByUsernamePartialMatch(username: string, skip = 0, limit = 10): Promise<Counted<Account[]>> {
 		return this.searchByUsername(username, skip, limit, false);
 	}
 
-	async deleteById(accountId: EntityId | ObjectId): Promise<void> {
-		const account = await this.findById(accountId);
-		return this.delete(account);
+	public async deleteById(accountId: EntityId | ObjectId): Promise<void> {
+		const entity = await this.em.findOneOrFail(AccountEntity, { id: accountId.toString() });
+		await this.em.removeAndFlush(entity);
 	}
 
-	async deleteByUserId(userId: EntityId): Promise<EntityId[]> {
-		const account = await this.findByUserId(userId);
-		if (account === null) {
+	public async deleteByUserId(userId: EntityId): Promise<EntityId[]> {
+		const entities = await this.em.find(this.entityName, { userId: new ObjectId(userId) });
+		if (entities.length === 0) {
 			return [];
 		}
-		await this._em.removeAndFlush(account);
+		await this.em.removeAndFlush(entities);
 
-		return [account.id];
+		return [entities[0].id];
 	}
 
 	/**
 	 * @deprecated For migration purpose only
 	 */
-	async findMany(offset = 0, limit = 100): Promise<AccountEntity[]> {
-		const result = await this._em.find(this.entityName, {}, { offset, limit, orderBy: { _id: SortOrder.asc } });
-		this._em.clear();
-		return result;
+	public async findMany(offset = 0, limit = 100): Promise<Account[]> {
+		const result = await this.em.find(this.entityName, {}, { offset, limit, orderBy: { _id: SortOrder.asc } });
+		this.em.clear();
+		return AccountEntityToDoMapper.mapEntitiesToDos(result);
 	}
 
 	private async searchByUsername(
@@ -87,10 +136,10 @@ export class AccountRepo extends BaseRepo<AccountEntity> {
 		offset: number,
 		limit: number,
 		exactMatch: boolean
-	): Promise<Counted<AccountEntity[]>> {
+	): Promise<Counted<Account[]>> {
 		const escapedUsername = username.replace(/[^(\p{L}\p{N})]/gu, '\\$&');
 		const searchUsername = exactMatch ? `^${escapedUsername}$` : escapedUsername;
-		return this._em.findAndCount(
+		const [entities, count] = await this.em.findAndCount(
 			this.entityName,
 			{
 				// NOTE: The default behavior of the MongoDB driver allows
@@ -105,5 +154,7 @@ export class AccountRepo extends BaseRepo<AccountEntity> {
 				orderBy: { username: 1 },
 			}
 		);
+		const accounts = AccountEntityToDoMapper.mapEntitiesToDos(entities);
+		return [accounts, count];
 	}
 }

--- a/apps/server/src/modules/account/repo/mapper/account-do-to-entity.mapper.spec.ts
+++ b/apps/server/src/modules/account/repo/mapper/account-do-to-entity.mapper.spec.ts
@@ -1,0 +1,58 @@
+import { accountDtoFactory } from '@shared/testing';
+import { ObjectId } from 'bson';
+import { AccountDoToEntityMapper } from './account-do-to-entity.mapper';
+
+describe('AccountEntityToDoMapper', () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+		jest.setSystemTime(new Date(2020, 1, 1));
+	});
+
+	afterEach(() => {
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
+	});
+
+	describe('mapToEntity', () => {
+		describe('When mapping Account DO to AccountEntity', () => {
+			const setup = () => {
+				const account = accountDtoFactory.build({
+					password: 'password',
+					credentialHash: 'credentialHash',
+					userId: new ObjectId().toHexString(),
+					systemId: new ObjectId().toHexString(),
+					expiresAt: new Date(),
+					lasttriedFailedLogin: new Date(),
+					token: 'token',
+					activated: true,
+					idmReferenceId: 'idmReferenceId',
+				});
+
+				return { account };
+			};
+
+			it('should map all fields', () => {
+				const { account } = setup();
+
+				const ret = AccountDoToEntityMapper.mapToEntity(account);
+
+				const expected = {
+					password: account.password,
+					credentialHash: account.credentialHash,
+					userId: new ObjectId(account.userId),
+					systemId: new ObjectId(account.systemId),
+					expiresAt: account.expiresAt,
+					lasttriedFailedLogin: account.lasttriedFailedLogin,
+					token: account.token,
+					activated: account.activated,
+					id: account.id,
+					_id: new ObjectId(account.id),
+					createdAt: account.createdAt,
+					updatedAt: account.updatedAt,
+				};
+
+				expect(ret).toEqual(expect.objectContaining(expected));
+			});
+		});
+	});
+});

--- a/apps/server/src/modules/account/repo/mapper/account-do-to-entity.mapper.ts
+++ b/apps/server/src/modules/account/repo/mapper/account-do-to-entity.mapper.ts
@@ -1,0 +1,31 @@
+import { ObjectId } from 'bson';
+import { Account } from '../../domain';
+import { AccountEntity } from '../../entity/account.entity';
+
+export class AccountDoToEntityMapper {
+	public static mapToEntity(account: Account): AccountEntity {
+		const accountEntity = new AccountEntity({
+			userId: account.userId ? new ObjectId(account.userId) : undefined,
+			username: account.username,
+			activated: account.activated,
+			credentialHash: account.credentialHash,
+			expiresAt: account.expiresAt,
+			lasttriedFailedLogin: account.lasttriedFailedLogin,
+			password: account.password,
+			systemId: account.systemId ? new ObjectId(account.systemId) : undefined,
+			token: account.token,
+		});
+
+		if (account.id) {
+			accountEntity._id = new ObjectId(account.id);
+			accountEntity.id = accountEntity._id.toHexString();
+		}
+		if (account.createdAt) {
+			accountEntity.createdAt = account.createdAt;
+		}
+		if (account.updatedAt) {
+			accountEntity.updatedAt = account.updatedAt;
+		}
+		return accountEntity;
+	}
+}

--- a/apps/server/src/modules/account/repo/mapper/account-entity-to-do.mapper.spec.ts
+++ b/apps/server/src/modules/account/repo/mapper/account-entity-to-do.mapper.spec.ts
@@ -13,7 +13,7 @@ describe('AccountEntityToDoMapper', () => {
 		jest.useRealTimers();
 	});
 
-	describe('mapToDto', () => {
+	describe('mapToDo', () => {
 		describe('When mapping AccountEntity to Account', () => {
 			const setup = () => {
 				const accountEntity = accountFactory.withAllProperties().buildWithId({}, '000000000000000000000001');
@@ -26,7 +26,7 @@ describe('AccountEntityToDoMapper', () => {
 			it('should map all fields', () => {
 				const { accountEntity } = setup();
 
-				const ret = AccountEntityToDoMapper.mapToDto(accountEntity);
+				const ret = AccountEntityToDoMapper.mapToDo(accountEntity);
 
 				expect({ ...ret.getProps(), _id: accountEntity._id }).toMatchObject(accountEntity);
 			});
@@ -34,7 +34,7 @@ describe('AccountEntityToDoMapper', () => {
 			it('should ignore missing ids', () => {
 				const { missingSystemUserIdEntity } = setup();
 
-				const ret = AccountEntityToDoMapper.mapToDto(missingSystemUserIdEntity);
+				const ret = AccountEntityToDoMapper.mapToDo(missingSystemUserIdEntity);
 
 				expect(ret.userId).toBeUndefined();
 				expect(ret.systemId).toBeUndefined();
@@ -42,7 +42,7 @@ describe('AccountEntityToDoMapper', () => {
 		});
 	});
 
-	describe('mapSearchResult', () => {
+	describe('mapCountedEntities', () => {
 		describe('When mapping multiple Account entities', () => {
 			const setup = () => {
 				const testEntity1: AccountEntity = accountFactory.buildWithId({}, '000000000000000000000001');
@@ -58,7 +58,7 @@ describe('AccountEntityToDoMapper', () => {
 			it('should map exact same amount of entities', () => {
 				const { testEntities, testAmount } = setup();
 
-				const [accounts, total] = AccountEntityToDoMapper.mapSearchResult([testEntities, testAmount]);
+				const [accounts, total] = AccountEntityToDoMapper.mapCountedEntities([testEntities, testAmount]);
 
 				expect(total).toBe(testAmount);
 				expect(accounts).toHaveLength(2);
@@ -68,7 +68,7 @@ describe('AccountEntityToDoMapper', () => {
 		});
 	});
 
-	describe('mapAccountsToDto', () => {
+	describe('mapEntitiesToDos', () => {
 		describe('When mapping multiple Account entities', () => {
 			const setup = () => {
 				const testEntity1: AccountEntity = accountFactory.buildWithId({}, '000000000000000000000001');
@@ -82,7 +82,7 @@ describe('AccountEntityToDoMapper', () => {
 			it('should map all entities', () => {
 				const testEntities = setup();
 
-				const ret = AccountEntityToDoMapper.mapAccountsToDto(testEntities);
+				const ret = AccountEntityToDoMapper.mapEntitiesToDos(testEntities);
 
 				expect(ret).toHaveLength(2);
 				expect(ret).toContainEqual(expect.objectContaining({ id: '000000000000000000000001' }));

--- a/apps/server/src/modules/account/repo/mapper/account-entity-to-do.mapper.ts
+++ b/apps/server/src/modules/account/repo/mapper/account-entity-to-do.mapper.ts
@@ -3,7 +3,7 @@ import { Account } from '../../domain/account';
 import { AccountEntity } from '../../entity/account.entity';
 
 export class AccountEntityToDoMapper {
-	static mapToDto(account: AccountEntity): Account {
+	static mapToDo(account: AccountEntity): Account {
 		return new Account({
 			id: account.id,
 			createdAt: account.createdAt,
@@ -20,13 +20,13 @@ export class AccountEntityToDoMapper {
 		});
 	}
 
-	static mapSearchResult(accountEntities: Counted<AccountEntity[]>): Counted<Account[]> {
+	static mapCountedEntities(accountEntities: Counted<AccountEntity[]>): Counted<Account[]> {
 		const foundAccounts = accountEntities[0];
-		const accountDtos: Account[] = AccountEntityToDoMapper.mapAccountsToDto(foundAccounts);
+		const accountDtos: Account[] = AccountEntityToDoMapper.mapEntitiesToDos(foundAccounts);
 		return [accountDtos, accountEntities[1]];
 	}
 
-	static mapAccountsToDto(accounts: AccountEntity[]): Account[] {
-		return accounts.map((accountEntity) => AccountEntityToDoMapper.mapToDto(accountEntity));
+	static mapEntitiesToDos(accounts: AccountEntity[]): Account[] {
+		return accounts.map((accountEntity) => AccountEntityToDoMapper.mapToDo(accountEntity));
 	}
 }

--- a/apps/server/src/modules/account/services/account.service.ts
+++ b/apps/server/src/modules/account/services/account.service.ts
@@ -133,7 +133,7 @@ export class AccountService extends AbstractAccountService {
 		}
 		if (updateAccount) {
 			try {
-				await this.save(targetAccount);
+				return await this.save(targetAccount);
 			} catch (err) {
 				throw new EntityNotFoundError(AccountEntity.name);
 			}

--- a/apps/server/src/modules/account/services/account.validation.service.spec.ts
+++ b/apps/server/src/modules/account/services/account.validation.service.spec.ts
@@ -3,7 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { Role } from '@shared/domain/entity';
 import { Permission, RoleName } from '@shared/domain/interface';
 import { UserRepo } from '@shared/repo';
-import { accountFactory, setupEntities, systemFactory, userFactory } from '@shared/testing';
+import { accountDtoFactory, setupEntities, systemFactory, userFactory } from '@shared/testing';
 import { ObjectId } from 'bson';
 import { AccountRepo } from '../repo/account.repo';
 import { AccountValidationService } from './account.validation.service';
@@ -84,7 +84,7 @@ describe('AccountValidationService', () => {
 					roles: [new Role({ name: RoleName.STUDENT, permissions: [] })],
 				});
 
-				const mockStudentAccount = accountFactory.buildWithId({ userId: mockStudentUser.id });
+				const mockStudentAccount = accountDtoFactory.build({ userId: mockStudentUser.id });
 
 				userRepo.findByEmail.mockResolvedValueOnce([mockStudentUser]);
 				accountRepo.searchByUsernameExactMatch.mockResolvedValueOnce([[mockStudentAccount], 1]);
@@ -124,8 +124,8 @@ describe('AccountValidationService', () => {
 						}),
 					],
 				});
-				const mockAdminAccount = accountFactory.buildWithId({ userId: mockAdminUser.id });
-				const mockStudentAccount = accountFactory.buildWithId({ userId: mockStudentUser.id });
+				const mockAdminAccount = accountDtoFactory.build({ userId: mockAdminUser.id });
+				const mockStudentAccount = accountDtoFactory.build({ userId: mockStudentUser.id });
 
 				userRepo.findByEmail.mockResolvedValueOnce([mockAdminUser]);
 				accountRepo.searchByUsernameExactMatch.mockResolvedValueOnce([[mockAdminAccount], 1]);
@@ -152,8 +152,8 @@ describe('AccountValidationService', () => {
 					roles: [new Role({ name: RoleName.STUDENT, permissions: [] })],
 				});
 
-				const mockTeacherAccount = accountFactory.buildWithId({ userId: mockTeacherUser.id });
-				const mockStudentAccount = accountFactory.buildWithId({ userId: mockStudentUser.id });
+				const mockTeacherAccount = accountDtoFactory.build({ userId: mockTeacherUser.id });
+				const mockStudentAccount = accountDtoFactory.build({ userId: mockStudentUser.id });
 
 				userRepo.findByEmail.mockResolvedValueOnce([mockTeacherUser]);
 				accountRepo.searchByUsernameExactMatch.mockResolvedValueOnce([[mockTeacherAccount], 1]);
@@ -188,7 +188,7 @@ describe('AccountValidationService', () => {
 						}),
 					],
 				});
-				const mockStudentAccount = accountFactory.buildWithId({ userId: mockStudentUser.id });
+				const mockStudentAccount = accountDtoFactory.build({ userId: mockStudentUser.id });
 
 				const mockUsers = [mockTeacherUser, mockStudentUser, mockOtherTeacherUser];
 
@@ -226,9 +226,9 @@ describe('AccountValidationService', () => {
 					],
 				});
 
-				const mockTeacherAccount = accountFactory.buildWithId({ userId: mockTeacherUser.id });
-				const mockStudentAccount = accountFactory.buildWithId({ userId: mockStudentUser.id });
-				const mockOtherTeacherAccount = accountFactory.buildWithId({
+				const mockTeacherAccount = accountDtoFactory.build({ userId: mockTeacherUser.id });
+				const mockStudentAccount = accountDtoFactory.build({ userId: mockStudentUser.id });
+				const mockOtherTeacherAccount = accountDtoFactory.build({
 					userId: mockOtherTeacherUser.id,
 				});
 
@@ -261,12 +261,12 @@ describe('AccountValidationService', () => {
 
 				const externalSystemA = systemFactory.build();
 				const externalSystemB = systemFactory.build();
-				const mockExternalUserAccount = accountFactory.build({
+				const mockExternalUserAccount = accountDtoFactory.build({
 					userId: mockExternalUser.id,
 					username: 'unique.within@system',
 					systemId: externalSystemA.id,
 				});
-				const mockOtherExternalUserAccount = accountFactory.build({
+				const mockOtherExternalUserAccount = accountDtoFactory.build({
 					userId: mockOtherExternalUser.id,
 					username: 'unique.within@system',
 					systemId: externalSystemB.id,
@@ -297,7 +297,7 @@ describe('AccountValidationService', () => {
 					roles: [new Role({ name: RoleName.STUDENT, permissions: [] })],
 				});
 
-				const mockStudentAccount = accountFactory.buildWithId({ userId: mockStudentUser.id });
+				const mockStudentAccount = accountDtoFactory.build({ userId: mockStudentUser.id });
 
 				userRepo.findByEmail.mockResolvedValueOnce([mockStudentUser]);
 				accountRepo.searchByUsernameExactMatch.mockResolvedValueOnce([[mockStudentAccount], 1]);
@@ -318,7 +318,7 @@ describe('AccountValidationService', () => {
 					roles: [new Role({ name: RoleName.STUDENT, permissions: [] })],
 				});
 
-				const mockStudentAccount = accountFactory.buildWithId({ userId: mockStudentUser.id });
+				const mockStudentAccount = accountDtoFactory.build({ userId: mockStudentUser.id });
 
 				const mockAdminUser = userFactory.buildWithId({
 					roles: [
@@ -337,7 +337,7 @@ describe('AccountValidationService', () => {
 						}),
 					],
 				});
-				const mockAdminAccount = accountFactory.buildWithId({ userId: mockAdminUser.id });
+				const mockAdminAccount = accountDtoFactory.build({ userId: mockAdminUser.id });
 
 				userRepo.findByEmail.mockResolvedValueOnce([mockStudentUser]);
 				accountRepo.searchByUsernameExactMatch.mockResolvedValueOnce([[mockStudentAccount], 1]);
@@ -360,7 +360,7 @@ describe('AccountValidationService', () => {
 					roles: [new Role({ name: RoleName.STUDENT, permissions: [] })],
 				});
 
-				const mockStudentAccount = accountFactory.buildWithId({ userId: mockStudentUser.id });
+				const mockStudentAccount = accountDtoFactory.build({ userId: mockStudentUser.id });
 
 				userRepo.findByEmail.mockResolvedValueOnce([mockStudentUser]);
 				accountRepo.searchByUsernameExactMatch.mockResolvedValueOnce([[mockStudentAccount], 1]);
@@ -386,8 +386,8 @@ describe('AccountValidationService', () => {
 					roles: [new Role({ name: RoleName.STUDENT, permissions: [] })],
 				});
 
-				const mockTeacherAccount = accountFactory.buildWithId({ userId: mockTeacherUser.id });
-				const mockStudentAccount = accountFactory.buildWithId({ userId: mockStudentUser.id });
+				const mockTeacherAccount = accountDtoFactory.build({ userId: mockTeacherUser.id });
+				const mockStudentAccount = accountDtoFactory.build({ userId: mockStudentUser.id });
 
 				userRepo.findByEmail.mockResolvedValueOnce([mockStudentUser]);
 				accountRepo.searchByUsernameExactMatch.mockResolvedValueOnce([[mockStudentAccount], 1]);
@@ -407,10 +407,10 @@ describe('AccountValidationService', () => {
 
 		describe('When user is missing in account', () => {
 			const setup = () => {
-				const oprhanAccount = accountFactory.buildWithId({
+				const oprhanAccount = accountDtoFactory.build({
 					username: 'orphan@account',
 					userId: undefined,
-					systemId: new ObjectId(),
+					systemId: new ObjectId().toHexString(),
 				});
 
 				userRepo.findByEmail.mockResolvedValueOnce([]);

--- a/apps/server/src/modules/account/services/account.validation.service.ts
+++ b/apps/server/src/modules/account/services/account.validation.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common';
 import { EntityId } from '@shared/domain/types';
 import { UserRepo } from '@shared/repo';
 import { AccountRepo } from '../repo/account.repo';
-import { AccountEntityToDoMapper } from '../repo/mapper/account-entity-to-do.mapper';
 
 @Injectable()
 export class AccountValidationService {
@@ -10,9 +9,7 @@ export class AccountValidationService {
 
 	async isUniqueEmail(email: string, userId?: EntityId, accountId?: EntityId, systemId?: EntityId): Promise<boolean> {
 		const foundUsers = await this.userRepo.findByEmail(email);
-		const [accounts] = AccountEntityToDoMapper.mapSearchResult(
-			await this.accountRepo.searchByUsernameExactMatch(email)
-		);
+		const [accounts] = await this.accountRepo.searchByUsernameExactMatch(email);
 		const filteredAccounts = accounts.filter((foundAccount) => foundAccount.systemId === systemId);
 
 		const multipleUsers = foundUsers.length > 1;

--- a/apps/server/src/modules/account/uc/account.uc.spec.ts
+++ b/apps/server/src/modules/account/uc/account.uc.spec.ts
@@ -137,7 +137,7 @@ describe('AccountUc', () => {
 				authorizationService.checkAllPermissions.mockImplementation(() => {
 					throw new UnauthorizedException();
 				});
-				accountService.findByUserIdOrFail.mockResolvedValue(AccountEntityToDoMapper.mapToDto(mockStudentAccount));
+				accountService.findByUserIdOrFail.mockResolvedValue(AccountEntityToDoMapper.mapToDo(mockStudentAccount));
 				accountService.validatePassword.mockResolvedValue(true);
 
 				return { mockStudentUser };
@@ -188,7 +188,7 @@ describe('AccountUc', () => {
 				});
 
 				authorizationService.getUserWithPermissions.mockResolvedValue(mockAdminUser);
-				accountService.findByUserIdOrFail.mockResolvedValue(AccountEntityToDoMapper.mapToDto(mockAdminAccount));
+				accountService.findByUserIdOrFail.mockResolvedValue(AccountEntityToDoMapper.mapToDo(mockAdminAccount));
 				accountService.validatePassword.mockResolvedValue(true);
 
 				return { mockAdminUser };
@@ -229,7 +229,7 @@ describe('AccountUc', () => {
 				});
 
 				authorizationService.getUserWithPermissions.mockResolvedValue(mockSuperheroUser);
-				accountService.findByUserIdOrFail.mockResolvedValue(AccountEntityToDoMapper.mapToDto(mockSuperheroAccount));
+				accountService.findByUserIdOrFail.mockResolvedValue(AccountEntityToDoMapper.mapToDo(mockSuperheroAccount));
 				accountService.validatePassword.mockResolvedValue(true);
 
 				return { mockSuperheroUser };
@@ -289,7 +289,7 @@ describe('AccountUc', () => {
 				authorizationService.getUserWithPermissions
 					.mockResolvedValueOnce(mockSuperheroUser)
 					.mockResolvedValueOnce(mockStudentUser);
-				accountService.findByUserId.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDto(mockStudentAccount));
+				accountService.findByUserId.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDo(mockStudentAccount));
 
 				return { mockSuperheroUser, mockStudentUser, mockStudentAccount };
 			};
@@ -388,7 +388,7 @@ describe('AccountUc', () => {
 					.mockResolvedValueOnce(mockSuperheroUser)
 					.mockResolvedValueOnce(mockSuperheroUser);
 				accountService.searchByUsernamePartialMatch.mockResolvedValueOnce([
-					[AccountEntityToDoMapper.mapToDto(mockStudentAccount), AccountEntityToDoMapper.mapToDto(mockStudentAccount)],
+					[AccountEntityToDoMapper.mapToDo(mockStudentAccount), AccountEntityToDoMapper.mapToDo(mockStudentAccount)],
 					2,
 				]);
 
@@ -1260,7 +1260,7 @@ describe('AccountUc', () => {
 				});
 
 				authorizationService.getUserWithPermissions.mockResolvedValueOnce(mockSuperheroUser);
-				accountService.findById.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDto(mockStudentAccount));
+				accountService.findById.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDo(mockStudentAccount));
 
 				return { mockSuperheroUser, mockStudentUser, mockStudentAccount };
 			};
@@ -1462,7 +1462,7 @@ describe('AccountUc', () => {
 				});
 
 				authorizationService.getUserWithPermissions.mockResolvedValue(mockAdminUser);
-				accountService.findById.mockResolvedValue(AccountEntityToDoMapper.mapToDto(mockAccountWithoutUser));
+				accountService.findById.mockResolvedValue(AccountEntityToDoMapper.mapToDo(mockAccountWithoutUser));
 
 				return { mockAdminUser };
 			};
@@ -1496,7 +1496,7 @@ describe('AccountUc', () => {
 				});
 
 				authorizationService.getUserWithPermissions.mockResolvedValueOnce(mockSuperheroUser);
-				accountService.findById.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDto(mockAccountWithoutUser));
+				accountService.findById.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDo(mockAccountWithoutUser));
 
 				return { mockSuperheroUser, mockAccountWithoutUser };
 			};
@@ -1552,7 +1552,7 @@ describe('AccountUc', () => {
 					authorizationService.getUserWithPermissions
 						.mockResolvedValueOnce(mockAdminUser)
 						.mockResolvedValueOnce(mockTeacherUser);
-					accountService.findById.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDto(mockTeacherAccount));
+					accountService.findById.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDo(mockTeacherAccount));
 					authorizationService.hasAllPermissions.mockReturnValue(true);
 
 					return { mockAdminUser, mockTeacherAccount };
@@ -1590,8 +1590,8 @@ describe('AccountUc', () => {
 					authorizationService.getUserWithPermissions
 						.mockResolvedValueOnce(mockTeacherUser)
 						.mockResolvedValueOnce(mockStudentUser);
-					accountService.findById.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDto(mockStudentAccount));
-					accountService.updateAccount.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDto(mockStudentAccount));
+					accountService.findById.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDo(mockStudentAccount));
+					accountService.updateAccount.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDo(mockStudentAccount));
 					authorizationService.hasAllPermissions.mockReturnValue(true);
 
 					return { mockStudentAccount, mockTeacherUser };
@@ -1637,8 +1637,8 @@ describe('AccountUc', () => {
 					authorizationService.getUserWithPermissions
 						.mockResolvedValueOnce(mockAdminUser)
 						.mockResolvedValueOnce(mockStudentUser);
-					accountService.findById.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDto(mockStudentAccount));
-					accountService.updateAccount.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDto(mockStudentAccount));
+					accountService.findById.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDo(mockStudentAccount));
+					accountService.updateAccount.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDo(mockStudentAccount));
 					authorizationService.hasAllPermissions.mockReturnValue(true);
 
 					return { mockStudentAccount, mockAdminUser };
@@ -1681,7 +1681,7 @@ describe('AccountUc', () => {
 					authorizationService.getUserWithPermissions
 						.mockResolvedValueOnce(mockTeacherUser)
 						.mockResolvedValueOnce(mockOtherTeacherUser);
-					accountService.findById.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDto(mockOtherTeacherAccount));
+					accountService.findById.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDo(mockOtherTeacherAccount));
 
 					return { mockOtherTeacherAccount, mockTeacherUser };
 				};
@@ -1740,7 +1740,7 @@ describe('AccountUc', () => {
 					authorizationService.getUserWithPermissions
 						.mockResolvedValueOnce(mockDifferentSchoolAdminUser)
 						.mockResolvedValueOnce(mockTeacherUser);
-					accountService.findById.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDto(mockTeacherAccount));
+					accountService.findById.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDo(mockTeacherAccount));
 
 					return { mockDifferentSchoolAdminUser, mockTeacherAccount };
 				};
@@ -1793,8 +1793,8 @@ describe('AccountUc', () => {
 					authorizationService.getUserWithPermissions
 						.mockResolvedValueOnce(mockSuperheroUser)
 						.mockResolvedValueOnce(mockAdminUser);
-					accountService.findById.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDto(mockAdminAccount));
-					accountService.updateAccount.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDto(mockAdminAccount));
+					accountService.findById.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDo(mockAdminAccount));
+					accountService.updateAccount.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDo(mockAdminAccount));
 					authorizationService.hasAllPermissions.mockReturnValue(true);
 
 					return { mockAdminAccount, mockSuperheroUser };
@@ -1827,7 +1827,7 @@ describe('AccountUc', () => {
 					authorizationService.getUserWithPermissions
 						.mockResolvedValueOnce(mockUnknownRoleUser)
 						.mockResolvedValueOnce(mockUserWithoutRole);
-					accountService.findById.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDto(mockAccountWithoutRole));
+					accountService.findById.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDo(mockAccountWithoutRole));
 
 					return { mockAccountWithoutRole, mockUnknownRoleUser };
 				};
@@ -1875,7 +1875,7 @@ describe('AccountUc', () => {
 					authorizationService.getUserWithPermissions
 						.mockResolvedValueOnce(mockAdminUser)
 						.mockResolvedValueOnce(mockUnknownRoleUser);
-					accountService.findById.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDto(mockUnknownRoleUserAccount));
+					accountService.findById.mockResolvedValueOnce(AccountEntityToDoMapper.mapToDo(mockUnknownRoleUserAccount));
 
 					return { mockAdminUser, mockUnknownRoleUserAccount };
 				};
@@ -1916,7 +1916,7 @@ describe('AccountUc', () => {
 				});
 
 				authorizationService.getUserWithPermissions.mockResolvedValue(mockSuperheroUser);
-				accountService.findById.mockResolvedValue(AccountEntityToDoMapper.mapToDto(mockStudentAccount));
+				accountService.findById.mockResolvedValue(AccountEntityToDoMapper.mapToDo(mockStudentAccount));
 
 				return { mockSuperheroUser, mockStudentAccount };
 			};

--- a/apps/server/src/modules/authentication/strategy/local.strategy.spec.ts
+++ b/apps/server/src/modules/authentication/strategy/local.strategy.spec.ts
@@ -33,7 +33,7 @@ describe('LocalStrategy', () => {
 		userRepoMock = createMock<UserRepo>();
 		strategy = new LocalStrategy(authenticationServiceMock, idmOauthServiceMock, configServiceMock, userRepoMock);
 		mockUser = userFactory.withRoleByName(RoleName.STUDENT).buildWithId();
-		mockAccount = AccountEntityToDoMapper.mapToDto(
+		mockAccount = AccountEntityToDoMapper.mapToDo(
 			accountFactory.buildWithId({ userId: mockUser.id, password: mockPasswordHash })
 		);
 	});


### PR DESCRIPTION
# Description
- AccountRepo now uses Account DO instead AccountEntity for parameters and return values

## Links to Tickets or other pull requests

- https://ticketsystem.dbildungscloud.de/browse/EW-742


## Approval for review

- [x] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
