### PR TITLE
EW-723: Control over topics.

### DIFF
--- a/apps/server/src/modules/learnroom/controller/api-test/course.api.spec.ts
+++ b/apps/server/src/modules/learnroom/controller/api-test/course.api.spec.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker/locale/af_ZA';
 import { EntityManager } from '@mikro-orm/mongodb';
 import { CourseMetadataListResponse } from '@modules/learnroom/controller/dto';
 import { ServerTestModule } from '@modules/server/server.module';
@@ -104,10 +105,10 @@ describe('Course Controller (API)', () => {
 			const { teacher, course } = setup();
 			await em.persistAndFlush([teacher.account, teacher.user, course]);
 			em.clear();
-			const version = { version: '1.1.0' };
+			const query = { version: '1.1.0', topics: faker.string.uuid() };
 
 			const loggedInClient = await testApiClient.login(teacher.account);
-			const response = await loggedInClient.get(`${course.id}/export`).query(version);
+			const response = await loggedInClient.get(`${course.id}/export`).query(query);
 
 			expect(response.statusCode).toEqual(200);
 			const file = response.body as StreamableFile;

--- a/apps/server/src/modules/learnroom/controller/course.controller.ts
+++ b/apps/server/src/modules/learnroom/controller/course.controller.ts
@@ -61,7 +61,12 @@ export class CourseController {
 		@Query() queryParams: CourseQueryParams,
 		@Res({ passthrough: true }) response: Response
 	): Promise<StreamableFile> {
-		const result = await this.courseExportUc.exportCourse(urlParams.courseId, currentUser.userId, queryParams.version);
+		const result = await this.courseExportUc.exportCourse(
+			urlParams.courseId,
+			currentUser.userId,
+			queryParams.version,
+			queryParams.topics?.split(',')
+		);
 
 		response.set({
 			'Content-Type': 'application/zip',

--- a/apps/server/src/modules/learnroom/controller/dto/course.query.params.ts
+++ b/apps/server/src/modules/learnroom/controller/dto/course.query.params.ts
@@ -1,6 +1,6 @@
 import { CommonCartridgeVersion } from '@modules/common-cartridge';
-import { ApiProperty } from '@nestjs/swagger';
-import { IsString, Matches } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, Matches } from 'class-validator';
 
 export class CourseQueryParams {
 	@IsString()
@@ -12,4 +12,11 @@ export class CourseQueryParams {
 		enum: CommonCartridgeVersion,
 	})
 	version!: CommonCartridgeVersion;
+
+	@IsString()
+	@IsOptional()
+	@ApiPropertyOptional({
+		description: 'The ids of topics which should be exported separated by a comma.',
+	})
+	topics?: string;
 }

--- a/apps/server/src/modules/learnroom/service/common-cartridge-export.service.spec.ts
+++ b/apps/server/src/modules/learnroom/service/common-cartridge-export.service.spec.ts
@@ -23,7 +23,7 @@ describe('CommonCartridgeExportService', () => {
 		`<${nodeName}>${value.toString()}</${nodeName}>`;
 	const getFileContent = (archive: AdmZip, filePath: string): string | undefined =>
 		archive.getEntry(filePath)?.getData().toString();
-	const setupParams = async (version: CommonCartridgeVersion) => {
+	const setupParams = async (version: CommonCartridgeVersion, exportTopics: boolean) => {
 		const course = courseFactory.teachersWithId(2).buildWithId();
 		const tasks = taskFactory.buildListWithId(2);
 		const lessons = lessonFactory.buildListWithId(1, {
@@ -68,7 +68,7 @@ describe('CommonCartridgeExportService', () => {
 		taskServiceMock.findBySingleParent.mockResolvedValue([tasks, tasks.length]);
 		configServiceMock.getOrThrow.mockReturnValue(faker.internet.url());
 
-		const buffer = await sut.exportCourse(course.id, faker.string.uuid(), version);
+		const buffer = await sut.exportCourse(course.id, faker.string.uuid(), version, exportTopics ? [lesson.id] : []);
 		const archive = new AdmZip(buffer);
 
 		return { archive, course, lessons, tasks, taskFromLesson };
@@ -111,7 +111,7 @@ describe('CommonCartridgeExportService', () => {
 
 	describe('exportCourse', () => {
 		describe('when using version 1.1', () => {
-			const setup = async () => setupParams(CommonCartridgeVersion.V_1_1_0);
+			const setup = async (exportTopics = true) => setupParams(CommonCartridgeVersion.V_1_1_0, exportTopics);
 
 			it('should use schema version 1.1.0', async () => {
 				const { archive } = await setup();
@@ -130,6 +130,14 @@ describe('CommonCartridgeExportService', () => {
 
 				lessons.forEach((lesson) => {
 					expect(getFileContent(archive, 'imsmanifest.xml')).toContain(createXmlString('title', lesson.name));
+				});
+			});
+
+			it("shouldn't add lessons if topics array is empty", async () => {
+				const { archive, lessons } = await setup(false);
+
+				lessons.forEach((lesson) => {
+					expect(getFileContent(archive, 'imsmanifest.xml')).not.toContain(createXmlString('title', lesson.name));
 				});
 			});
 
@@ -153,7 +161,7 @@ describe('CommonCartridgeExportService', () => {
 		});
 
 		describe('when using version 1.3', () => {
-			const setup = async () => setupParams(CommonCartridgeVersion.V_1_3_0);
+			const setup = async (exportTopics = true) => setupParams(CommonCartridgeVersion.V_1_3_0, exportTopics);
 
 			it('should use schema version 1.3.0', async () => {
 				const { archive } = await setup();
@@ -172,6 +180,14 @@ describe('CommonCartridgeExportService', () => {
 
 				lessons.forEach((lesson) => {
 					expect(getFileContent(archive, 'imsmanifest.xml')).toContain(createXmlString('title', lesson.name));
+				});
+			});
+
+			it("shouldn't add lessons if topics array is empty", async () => {
+				const { archive, lessons } = await setup(false);
+
+				lessons.forEach((lesson) => {
+					expect(getFileContent(archive, 'imsmanifest.xml')).not.toContain(createXmlString('title', lesson.name));
 				});
 			});
 

--- a/apps/server/src/modules/learnroom/service/common-cartridge-export.service.ts
+++ b/apps/server/src/modules/learnroom/service/common-cartridge-export.service.ts
@@ -21,13 +21,18 @@ export class CommonCartridgeExportService {
 		private readonly commonCartridgeMapper: CommonCartridgeMapper
 	) {}
 
-	public async exportCourse(courseId: EntityId, userId: EntityId, version: CommonCartridgeVersion): Promise<Buffer> {
+	public async exportCourse(
+		courseId: EntityId,
+		userId: EntityId,
+		version: CommonCartridgeVersion,
+		topics?: string[]
+	): Promise<Buffer> {
 		const course = await this.courseService.findById(courseId);
 		const builder = new CommonCartridgeFileBuilder(this.commonCartridgeMapper.mapCourseToManifest(version, course));
 
 		builder.addMetadata(this.commonCartridgeMapper.mapCourseToMetadata(course));
 
-		await this.addLessons(builder, courseId, version);
+		await this.addLessons(builder, courseId, version, topics);
 		await this.addTasks(builder, courseId, userId, version);
 
 		return builder.build();
@@ -36,11 +41,16 @@ export class CommonCartridgeExportService {
 	private async addLessons(
 		builder: CommonCartridgeFileBuilder,
 		courseId: EntityId,
-		version: CommonCartridgeVersion
+		version: CommonCartridgeVersion,
+		topics?: string[]
 	): Promise<void> {
 		const [lessons] = await this.lessonService.findByCourseIds([courseId]);
 
 		lessons.forEach((lesson) => {
+			if (topics && !topics.includes(lesson.id)) {
+				return;
+			}
+
 			const organizationBuilder = builder.addOrganization(this.commonCartridgeMapper.mapLessonToOrganization(lesson));
 
 			lesson.contents.forEach((content) => {

--- a/apps/server/src/modules/learnroom/uc/course-export.uc.spec.ts
+++ b/apps/server/src/modules/learnroom/uc/course-export.uc.spec.ts
@@ -4,6 +4,7 @@ import { CommonCartridgeVersion } from '@modules/common-cartridge';
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
+import { faker } from '@faker-js/faker';
 import { AuthorizationReferenceService } from '../../authorization/domain';
 import { LearnroomConfig } from '../learnroom.config';
 import { CommonCartridgeExportService } from '../service/common-cartridge-export.service';
@@ -54,8 +55,9 @@ describe('CourseExportUc', () => {
 			const courseId = new ObjectId().toHexString();
 			const userId = new ObjectId().toHexString();
 			const version: CommonCartridgeVersion = CommonCartridgeVersion.V_1_1_0;
+			const topics: string[] = [faker.string.uuid()];
 
-			return { version, userId, courseId };
+			return { version, userId, courseId, topics };
 		};
 
 		describe('when authorization throw a error', () => {
@@ -68,9 +70,9 @@ describe('CourseExportUc', () => {
 			};
 
 			it('should pass this error', async () => {
-				const { courseId, userId, version } = setup();
+				const { courseId, userId, version, topics } = setup();
 
-				await expect(courseExportUc.exportCourse(courseId, userId, version)).rejects.toThrowError(
+				await expect(courseExportUc.exportCourse(courseId, userId, version, topics)).rejects.toThrowError(
 					new ForbiddenException()
 				);
 			});
@@ -86,9 +88,9 @@ describe('CourseExportUc', () => {
 			};
 
 			it('should pass this error', async () => {
-				const { courseId, userId, version } = setup();
+				const { courseId, userId, version, topics } = setup();
 
-				await expect(courseExportUc.exportCourse(courseId, userId, version)).rejects.toThrowError(new Error());
+				await expect(courseExportUc.exportCourse(courseId, userId, version, topics)).rejects.toThrowError(new Error());
 			});
 		});
 
@@ -102,16 +104,16 @@ describe('CourseExportUc', () => {
 			};
 
 			it('should check for permissions', async () => {
-				const { courseId, userId, version } = setup();
+				const { courseId, userId, version, topics } = setup();
 
-				await expect(courseExportUc.exportCourse(courseId, userId, version)).resolves.not.toThrow();
+				await expect(courseExportUc.exportCourse(courseId, userId, version, topics)).resolves.not.toThrow();
 				expect(authorizationServiceMock.checkPermissionByReferences).toBeCalledTimes(1);
 			});
 
 			it('should return a binary file as buffer', async () => {
-				const { courseId, userId, version } = setup();
+				const { courseId, userId, version, topics } = setup();
 
-				await expect(courseExportUc.exportCourse(courseId, userId, version)).resolves.toBeInstanceOf(Buffer);
+				await expect(courseExportUc.exportCourse(courseId, userId, version, topics)).resolves.toBeInstanceOf(Buffer);
 			});
 		});
 
@@ -125,9 +127,9 @@ describe('CourseExportUc', () => {
 			};
 
 			it('should throw a NotFoundException', async () => {
-				const { courseId, userId, version } = setup();
+				const { courseId, userId, version, topics } = setup();
 
-				await expect(courseExportUc.exportCourse(courseId, userId, version)).rejects.toThrowError(
+				await expect(courseExportUc.exportCourse(courseId, userId, version, topics)).rejects.toThrowError(
 					new NotFoundException()
 				);
 			});

--- a/apps/server/src/modules/learnroom/uc/course-export.uc.ts
+++ b/apps/server/src/modules/learnroom/uc/course-export.uc.ts
@@ -16,7 +16,12 @@ export class CourseExportUc {
 		private readonly authorizationService: AuthorizationReferenceService
 	) {}
 
-	async exportCourse(courseId: EntityId, userId: EntityId, version: CommonCartridgeVersion): Promise<Buffer> {
+	public async exportCourse(
+		courseId: EntityId,
+		userId: EntityId,
+		version: CommonCartridgeVersion,
+		topics?: string[]
+	): Promise<Buffer> {
 		this.checkFeatureEnabled();
 		const context = AuthorizationContextBuilder.read([Permission.COURSE_EDIT]);
 		await this.authorizationService.checkPermissionByReferences(
@@ -26,7 +31,7 @@ export class CourseExportUc {
 			context
 		);
 
-		return this.courseExportService.exportCourse(courseId, userId, version);
+		return this.courseExportService.exportCourse(courseId, userId, version, topics);
 	}
 
 	private checkFeatureEnabled(): void {


### PR DESCRIPTION
# Description
User can now control the topics that get exported.

## Links to Tickets or other pull requests
<!--- https://github.com/hpi-schul-cloud/schulcloud-client/pull/???? -->
- https://ticketsystem.dbildungscloud.de/browse/EW-723

## Approval for review

- [ ] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
