### PR TITLE
BC-5374 - add endpoint /v3/courses/:id/userPermissions

### DIFF
--- a/apps/server/src/modules/learnroom/controller/course.controller.ts
+++ b/apps/server/src/modules/learnroom/controller/course.controller.ts
@@ -108,4 +108,17 @@ export class CourseController {
 	): Promise<void> {
 		await this.courseSyncUc.stopSynchronization(currentUser.userId, params.courseId);
 	}
+
+	@Get(':courseId/userPermissions')
+	@ApiOperation({ summary: 'Get permissions for a user in a course.' })
+	public async getUserPermissions(
+		@CurrentUser() currentUser: ICurrentUser,
+		@Param() params: CourseUrlParams
+	): Promise<{ [userId: string]: string[] }> {
+		const permissions = await this.courseUc.getUserPermissionByCourseId(currentUser.userId, params.courseId);
+
+		return {
+			[currentUser.userId]: permissions,
+		};
+	}
 }

--- a/apps/server/src/modules/learnroom/controller/dto/course-user-permissions.response.ts
+++ b/apps/server/src/modules/learnroom/controller/dto/course-user-permissions.response.ts
@@ -1,0 +1,69 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { PaginationResponse } from '@shared/controller';
+import { EntityId } from '@shared/domain/types';
+
+export class CourseMetadataResponse {
+	constructor(
+		id: EntityId,
+		title: string,
+		shortTitle: string,
+		displayColor: string,
+		startDate?: Date,
+		untilDate?: Date,
+		copyingSince?: Date
+	) {
+		this.id = id;
+		this.title = title;
+		this.shortTitle = shortTitle;
+		this.displayColor = displayColor;
+		this.startDate = startDate;
+		this.untilDate = untilDate;
+		this.copyingSince = copyingSince;
+	}
+
+	@ApiProperty({
+		description: 'The id of the Grid element',
+		pattern: '[a-f0-9]{24}',
+	})
+	id: string;
+
+	@ApiProperty({
+		description: 'Title of the Grid element',
+	})
+	title: string;
+
+	@ApiProperty({
+		description: 'Short title of the Grid element',
+	})
+	shortTitle: string;
+
+	@ApiProperty({
+		description: 'Color of the Grid element',
+	})
+	displayColor: string;
+
+	@ApiPropertyOptional({
+		description: 'Start date of the course',
+	})
+	startDate?: Date;
+
+	@ApiPropertyOptional({
+		description: 'End date of the course. After this the course counts as archived',
+	})
+	untilDate?: Date;
+
+	@ApiPropertyOptional({
+		description: 'Start of the copying process if it is still ongoing - otherwise property is not set.',
+	})
+	copyingSince?: Date;
+}
+
+export class CourseMetadataListResponse extends PaginationResponse<CourseMetadataResponse[]> {
+	constructor(data: CourseMetadataResponse[], total: number, skip?: number, limit?: number) {
+		super(total, skip, limit);
+		this.data = data;
+	}
+
+	@ApiProperty({ type: [CourseMetadataResponse] })
+	data: CourseMetadataResponse[];
+}

--- a/apps/server/src/modules/learnroom/learnroom-api.module.ts
+++ b/apps/server/src/modules/learnroom/learnroom-api.module.ts
@@ -3,7 +3,7 @@ import { AuthorizationReferenceModule } from '@modules/authorization/authorizati
 import { CopyHelperModule } from '@modules/copy-helper';
 import { LessonModule } from '@modules/lesson';
 import { Module } from '@nestjs/common';
-import { CourseRepo, DashboardModelMapper, DashboardRepo, LegacyBoardRepo, UserRepo } from '@shared/repo';
+import { CourseRepo, DashboardModelMapper, DashboardRepo, LegacyBoardRepo, RoleRepo, UserRepo } from '@shared/repo';
 import { CourseController } from './controller/course.controller';
 import { DashboardController } from './controller/dashboard.controller';
 import { RoomsController } from './controller/rooms.controller';
@@ -21,6 +21,7 @@ import {
 	RoomsAuthorisationService,
 	RoomsUc,
 } from './uc';
+import { RoleService } from '../role';
 
 @Module({
 	imports: [AuthorizationModule, LessonModule, CopyHelperModule, LearnroomModule, AuthorizationReferenceModule],
@@ -44,6 +45,8 @@ import {
 		},
 		DashboardModelMapper,
 		CourseRepo,
+		RoleRepo,
+		RoleService,
 		UserRepo,
 		LegacyBoardRepo,
 	],

--- a/apps/server/src/modules/learnroom/mapper/rolename.mapper.spec.ts
+++ b/apps/server/src/modules/learnroom/mapper/rolename.mapper.spec.ts
@@ -1,0 +1,34 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RoleName } from '@shared/domain/interface';
+import { UserAndAccountTestFactory, courseFactory, setupEntities } from '@shared/testing';
+import { RoleNameMapper } from './rolename.mapper';
+
+describe('rolename mapper', () => {
+	let module: TestingModule;
+
+	afterAll(async () => {
+		await module.close();
+	});
+
+	beforeAll(async () => {
+		await setupEntities();
+		module = await Test.createTestingModule({
+			imports: [],
+			providers: [],
+		}).compile();
+	});
+
+	const setup = () => {
+		const { teacherUser } = UserAndAccountTestFactory.buildTeacher({}, []);
+		const course = courseFactory.build({
+			teachers: [teacherUser],
+		});
+
+		return { teacherUser, course };
+	};
+	it('should map teacher correctly', () => {
+		const { teacherUser, course } = setup();
+		const value = RoleNameMapper.mapToRoleName(teacherUser, course);
+		expect(value).toBe(RoleName.TEACHER);
+	});
+});

--- a/apps/server/src/modules/learnroom/mapper/rolename.mapper.ts
+++ b/apps/server/src/modules/learnroom/mapper/rolename.mapper.ts
@@ -1,0 +1,37 @@
+import { EntityDTO } from '@mikro-orm/core';
+import { Course, Role, User } from '@shared/domain/entity';
+import { RoleName } from '@shared/domain/interface';
+
+export class RoleNameMapper {
+	private static isSuperHero(roles: EntityDTO<Role>[]): boolean {
+		return roles.some((role) => role.name === RoleName.SUPERHERO);
+	}
+
+	private static isAdministrator(roles: EntityDTO<Role>[], user: User, course: Course): boolean {
+		const belongsToSameSchool = user.school.id === course.school.id;
+		const isAdministrator = roles.some((role) => role.name === RoleName.ADMINISTRATOR);
+		return belongsToSameSchool && isAdministrator;
+	}
+
+	private static isTeacher(user: User, course: Course): boolean {
+		return course.getTeacherIds().includes(user.id);
+	}
+
+	private static isSubstitutionTeacher(user: User, course: Course): boolean {
+		return course.getSubstitutionTeacherIds().includes(user.id);
+	}
+
+	private static isStudent(user: User, course: Course): boolean {
+		return course.getStudentIds().includes(user.id);
+	}
+
+	static mapToRoleName(user: User, course: Course): RoleName {
+		if (RoleNameMapper.isSuperHero(user.roles.toArray())) return RoleName.SUPERHERO;
+		if (RoleNameMapper.isAdministrator(user.roles.toArray(), user, course)) return RoleName.ADMINISTRATOR;
+		if (RoleNameMapper.isTeacher(user, course)) return RoleName.TEACHER;
+		if (RoleNameMapper.isSubstitutionTeacher(user, course)) return RoleName.COURSESUBSTITUTIONTEACHER;
+		if (RoleNameMapper.isStudent(user, course)) return RoleName.STUDENT;
+
+		throw new Error('Role not found');
+	}
+}

--- a/apps/server/src/modules/learnroom/uc/course.uc.spec.ts
+++ b/apps/server/src/modules/learnroom/uc/course.uc.spec.ts
@@ -1,14 +1,20 @@
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
-import { SortOrder } from '@shared/domain/interface';
+import { Permission, RoleName, SortOrder } from '@shared/domain/interface';
 import { CourseRepo } from '@shared/repo';
-import { courseFactory, setupEntities } from '@shared/testing';
+import { courseFactory, setupEntities, UserAndAccountTestFactory } from '@shared/testing';
+import { AuthorizationService } from '@src/modules/authorization';
+import { RoleDto, RoleService } from '@src/modules/role';
 import { CourseUc } from './course.uc';
+import { CourseService } from '../service';
 
 describe('CourseUc', () => {
 	let module: TestingModule;
 	let uc: CourseUc;
 	let courseRepo: DeepMocked<CourseRepo>;
+	let courseService: DeepMocked<CourseService>;
+	let authorizationService: DeepMocked<AuthorizationService>;
+	let roleService: DeepMocked<RoleService>;
 
 	beforeAll(async () => {
 		await setupEntities();
@@ -19,11 +25,26 @@ describe('CourseUc', () => {
 					provide: CourseRepo,
 					useValue: createMock<CourseRepo>(),
 				},
+				{
+					provide: CourseService,
+					useValue: createMock<CourseService>(),
+				},
+				{
+					provide: AuthorizationService,
+					useValue: createMock<AuthorizationService>(),
+				},
+				{
+					provide: RoleService,
+					useValue: createMock<RoleService>(),
+				},
 			],
 		}).compile();
 
 		uc = module.get(CourseUc);
 		courseRepo = module.get(CourseRepo);
+		courseService = module.get(CourseService);
+		authorizationService = module.get(AuthorizationService);
+		roleService = module.get(RoleService);
 	});
 
 	afterAll(async () => {
@@ -53,6 +74,33 @@ describe('CourseUc', () => {
 			const resultingOptions = { pagination, order: { updatedAt: SortOrder.desc } };
 			await uc.findAllByUser('someUserId', pagination);
 			expect(courseRepo.findAllByUserId).toHaveBeenCalledWith('someUserId', {}, resultingOptions);
+		});
+	});
+
+	describe('getUserPermissionByCourseId', () => {
+		const setup = () => {
+			const { teacherUser } = UserAndAccountTestFactory.buildTeacher({}, []);
+			const course = courseFactory.buildWithId({
+				teachers: [teacherUser],
+			});
+
+			return { course, teacherUser };
+		};
+		it('should return permissions for user', async () => {
+			const { course, teacherUser } = setup();
+			courseService.findById.mockResolvedValue(course);
+			authorizationService.getUserWithPermissions.mockResolvedValue(teacherUser);
+			const mockRoleDto: RoleDto = {
+				name: RoleName.TEACHER,
+				permissions: [Permission.COURSE_DELETE],
+			};
+			roleService.findByName.mockResolvedValue(mockRoleDto);
+			const permissions = await uc.getUserPermissionByCourseId(teacherUser.id, course.id);
+
+			expect(permissions.length).toBeGreaterThan(0);
+			expect(courseService.findById).toHaveBeenCalledWith(course.id);
+			expect(authorizationService.getUserWithPermissions).toHaveBeenCalledWith(teacherUser.id);
+			expect(roleService.findByName).toHaveBeenCalledWith(RoleName.TEACHER);
 		});
 	});
 });

--- a/apps/server/src/modules/learnroom/uc/course.uc.ts
+++ b/apps/server/src/modules/learnroom/uc/course.uc.ts
@@ -4,12 +4,30 @@ import { Course } from '@shared/domain/entity';
 import { SortOrder } from '@shared/domain/interface';
 import { Counted, EntityId } from '@shared/domain/types';
 import { CourseRepo } from '@shared/repo';
+import { AuthorizationService } from '@src/modules/authorization';
+import { RoleService } from '@src/modules/role';
+import { RoleNameMapper } from '../mapper/rolename.mapper';
+import { CourseService } from '../service';
 
 @Injectable()
 export class CourseUc {
-	public constructor(private readonly courseRepo: CourseRepo) {}
+	public constructor(
+		private readonly courseRepo: CourseRepo,
+		private readonly courseService: CourseService,
+		private readonly authService: AuthorizationService,
+		private readonly roleService: RoleService
+	) {}
 
 	public findAllByUser(userId: EntityId, options?: PaginationParams): Promise<Counted<Course[]>> {
 		return this.courseRepo.findAllByUserId(userId, {}, { pagination: options, order: { updatedAt: SortOrder.desc } });
+	}
+
+	public async getUserPermissionByCourseId(userId: EntityId, courseId: EntityId): Promise<string[]> {
+		const course = await this.courseService.findById(courseId);
+		const user = await this.authService.getUserWithPermissions(userId);
+		const userRole = RoleNameMapper.mapToRoleName(user, course);
+		const role = await this.roleService.findByName(userRole);
+
+		return role.permissions ?? [];
 	}
 }


### PR DESCRIPTION
# Description
Migrate /v1/courses/:id/userPermissions -> /v3/courses/:id/userPermissions.

The old code is still needed in the legacy client and is not removed in feathersjs.

## Links to Tickets or other pull requests
[Ticket](https://ticketsystem.dbildungscloud.de/browse/BC-5374)

## Changes
Add new api, uc.method and mapper in module learnroom.


## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review

- [ ] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
