### PR TITLE
EW-798 expanded cc export of rich text elements of column board

### DIFF
--- a/apps/server/src/modules/learnroom/mapper/common-cartridge.mapper.spec.ts
+++ b/apps/server/src/modules/learnroom/mapper/common-cartridge.mapper.spec.ts
@@ -16,6 +16,8 @@ import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ComponentProperties, ComponentType } from '@shared/domain/entity';
 import { courseFactory, lessonFactory, setupEntities, taskFactory, userFactory } from '@shared/testing';
+import { RichTextElement, RichTextElementProps } from '@shared/domain/domainobject';
+import { InputFormat } from '@shared/domain/types';
 import { LearnroomConfig } from '../learnroom.config';
 import { CommonCartridgeMapper } from './common-cartridge.mapper';
 
@@ -393,6 +395,38 @@ describe('CommonCartridgeMapper', () => {
 				expect(fileBuilderProps).toStrictEqual<CommonCartridgeFileBuilderProps>({
 					version: CommonCartridgeVersion.V_1_1_0,
 					identifier: createIdentifier(course.id),
+				});
+			});
+		});
+	});
+
+	describe('mapRichTextElementToResource', () => {
+		describe('when mapping rich text element', () => {
+			const setup = () => {
+				const richTextElementProps: RichTextElementProps = {
+					text: faker.lorem.paragraph(),
+					inputFormat: InputFormat.RICH_TEXT_CK5,
+					id: faker.string.uuid(),
+					createdAt: faker.date.recent(),
+					updatedAt: faker.date.recent(),
+				};
+				const richTextElement = new RichTextElement(richTextElementProps);
+
+				configServiceMock.getOrThrow.mockReturnValue(faker.internet.url());
+
+				return { richTextElement };
+			};
+
+			it('should map to web content', () => {
+				const { richTextElement } = setup();
+				const resourceProps = sut.mapRichTextElementToResource(richTextElement);
+
+				expect(resourceProps).toStrictEqual<CommonCartridgeResourceProps>({
+					type: CommonCartridgeResourceType.WEB_CONTENT,
+					identifier: expect.any(String),
+					title: 'card content',
+					html: `<p>${richTextElement.text}</p>`,
+					intendedUse: CommonCartridgeIntendedUseType.UNSPECIFIED,
 				});
 			});
 		});

--- a/apps/server/src/modules/learnroom/mapper/common-cartridge.mapper.spec.ts
+++ b/apps/server/src/modules/learnroom/mapper/common-cartridge.mapper.spec.ts
@@ -419,6 +419,7 @@ describe('CommonCartridgeMapper', () => {
 
 			it('should map to web content', () => {
 				const { richTextElement } = setup();
+
 				const resourceProps = sut.mapRichTextElementToResource(richTextElement);
 
 				expect(resourceProps).toStrictEqual<CommonCartridgeResourceProps>({

--- a/apps/server/src/modules/learnroom/mapper/common-cartridge.mapper.spec.ts
+++ b/apps/server/src/modules/learnroom/mapper/common-cartridge.mapper.spec.ts
@@ -424,7 +424,7 @@ describe('CommonCartridgeMapper', () => {
 				expect(resourceProps).toStrictEqual<CommonCartridgeResourceProps>({
 					type: CommonCartridgeResourceType.WEB_CONTENT,
 					identifier: expect.any(String),
-					title: 'card content',
+					title: 'content',
 					html: `<p>${richTextElement.text}</p>`,
 					intendedUse: CommonCartridgeIntendedUseType.UNSPECIFIED,
 				});

--- a/apps/server/src/modules/learnroom/mapper/common-cartridge.mapper.spec.ts
+++ b/apps/server/src/modules/learnroom/mapper/common-cartridge.mapper.spec.ts
@@ -425,7 +425,7 @@ describe('CommonCartridgeMapper', () => {
 				expect(resourceProps).toStrictEqual<CommonCartridgeResourceProps>({
 					type: CommonCartridgeResourceType.WEB_CONTENT,
 					identifier: expect.any(String),
-					title: 'content',
+					title: richTextElement.text.slice(0, 50).concat('...'),
 					html: `<p>${richTextElement.text}</p>`,
 					intendedUse: CommonCartridgeIntendedUseType.UNSPECIFIED,
 				});

--- a/apps/server/src/modules/learnroom/mapper/common-cartridge.mapper.ts
+++ b/apps/server/src/modules/learnroom/mapper/common-cartridge.mapper.ts
@@ -123,7 +123,7 @@ export class CommonCartridgeMapper {
 		return {
 			type: CommonCartridgeResourceType.WEB_CONTENT,
 			identifier: createIdentifier(element.id),
-			title: 'content',
+			title: element.text.slice(0, 50).concat('...'),
 			html: `<p>${element.text}</p>`,
 			intendedUse: CommonCartridgeIntendedUseType.UNSPECIFIED,
 		};

--- a/apps/server/src/modules/learnroom/mapper/common-cartridge.mapper.ts
+++ b/apps/server/src/modules/learnroom/mapper/common-cartridge.mapper.ts
@@ -124,7 +124,7 @@ export class CommonCartridgeMapper {
 			type: CommonCartridgeResourceType.WEB_CONTENT,
 			identifier: createIdentifier(element.id),
 			title: 'card content',
-			html: `<h1>${element.inputFormat}</h1><p>${element.text}</p>`,
+			html: `<p>${element.text}</p>`,
 			intendedUse: CommonCartridgeIntendedUseType.UNSPECIFIED,
 		};
 	}

--- a/apps/server/src/modules/learnroom/mapper/common-cartridge.mapper.ts
+++ b/apps/server/src/modules/learnroom/mapper/common-cartridge.mapper.ts
@@ -12,6 +12,7 @@ import {
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ComponentProperties, ComponentType, Course, LessonEntity, Task } from '@shared/domain/entity';
+import { RichTextElement } from '@shared/domain/domainobject';
 import { LearnroomConfig } from '../learnroom.config';
 
 @Injectable()
@@ -115,6 +116,16 @@ export class CommonCartridgeMapper {
 		return {
 			version,
 			identifier: createIdentifier(course.id),
+		};
+	}
+
+	public mapRichTextElementToResource(element: RichTextElement): CommonCartridgeResourceProps {
+		return {
+			type: CommonCartridgeResourceType.WEB_CONTENT,
+			identifier: createIdentifier(element.id),
+			title: element.inputFormat,
+			html: `<h1>${element.inputFormat}</h1><p>${element.text}</p>`,
+			intendedUse: CommonCartridgeIntendedUseType.UNSPECIFIED,
 		};
 	}
 }

--- a/apps/server/src/modules/learnroom/mapper/common-cartridge.mapper.ts
+++ b/apps/server/src/modules/learnroom/mapper/common-cartridge.mapper.ts
@@ -122,10 +122,18 @@ export class CommonCartridgeMapper {
 	public mapRichTextElementToResource(element: RichTextElement): CommonCartridgeResourceProps {
 		return {
 			type: CommonCartridgeResourceType.WEB_CONTENT,
+			title: this.getTextTitle(element.text),
 			identifier: createIdentifier(element.id),
-			title: element.text.slice(0, 50).concat('...'),
 			html: `<p>${element.text}</p>`,
 			intendedUse: CommonCartridgeIntendedUseType.UNSPECIFIED,
 		};
+	}
+
+	private getTextTitle(text: string): string {
+		const title = text
+			.slice(0, 50)
+			.replace(/<[^>]*>?/gm, '')
+			.concat('...');
+		return title;
 	}
 }

--- a/apps/server/src/modules/learnroom/mapper/common-cartridge.mapper.ts
+++ b/apps/server/src/modules/learnroom/mapper/common-cartridge.mapper.ts
@@ -123,7 +123,7 @@ export class CommonCartridgeMapper {
 		return {
 			type: CommonCartridgeResourceType.WEB_CONTENT,
 			identifier: createIdentifier(element.id),
-			title: element.inputFormat,
+			title: 'card content',
 			html: `<h1>${element.inputFormat}</h1><p>${element.text}</p>`,
 			intendedUse: CommonCartridgeIntendedUseType.UNSPECIFIED,
 		};

--- a/apps/server/src/modules/learnroom/mapper/common-cartridge.mapper.ts
+++ b/apps/server/src/modules/learnroom/mapper/common-cartridge.mapper.ts
@@ -123,7 +123,7 @@ export class CommonCartridgeMapper {
 		return {
 			type: CommonCartridgeResourceType.WEB_CONTENT,
 			identifier: createIdentifier(element.id),
-			title: 'card content',
+			title: 'content',
 			html: `<p>${element.text}</p>`,
 			intendedUse: CommonCartridgeIntendedUseType.UNSPECIFIED,
 		};

--- a/apps/server/src/modules/learnroom/service/common-cartridge-export.service.spec.ts
+++ b/apps/server/src/modules/learnroom/service/common-cartridge-export.service.spec.ts
@@ -18,6 +18,7 @@ import {
 } from '@shared/testing';
 import { ColumnBoardService } from '@src/modules/board';
 import AdmZip from 'adm-zip';
+import { ContentElementFactory, ContentElementType } from '@shared/domain/domainobject';
 import { CommonCartridgeMapper } from '../mapper/common-cartridge.mapper';
 
 describe('CommonCartridgeExportService', () => {
@@ -28,6 +29,7 @@ describe('CommonCartridgeExportService', () => {
 	let taskServiceMock: DeepMocked<TaskService>;
 	let configServiceMock: DeepMocked<ConfigService<LearnroomConfig, true>>;
 	let columnBoardServiceMock: DeepMocked<ColumnBoardService>;
+	const contentElementFactory = new ContentElementFactory();
 
 	const createXmlString = (nodeName: string, value: boolean | number | string): string =>
 		`<${nodeName}>${value.toString()}</${nodeName}>`;
@@ -71,7 +73,8 @@ describe('CommonCartridgeExportService', () => {
 		});
 		const [lesson] = lessons;
 		const taskFromLesson = taskFactory.buildWithId({ course, lesson });
-		const card = cardFactory.build();
+		const contentElement = contentElementFactory.build(ContentElementType.RICH_TEXT);
+		const card = cardFactory.build({ children: [contentElement] });
 		const column = columnFactory.build({ children: [card] });
 		const columnBoard = columnBoardFactory.build({ children: [column] });
 
@@ -92,7 +95,7 @@ describe('CommonCartridgeExportService', () => {
 		);
 		const archive = new AdmZip(buffer);
 
-		return { archive, course, lessons, tasks, taskFromLesson, columnBoard, column, card };
+		return { archive, course, lessons, tasks, taskFromLesson, columnBoard, column, card, contentElement };
 	};
 
 	beforeAll(async () => {
@@ -259,6 +262,13 @@ describe('CommonCartridgeExportService', () => {
 				const manifest = getFileContent(archive, 'imsmanifest.xml');
 
 				expect(manifest).toContain(createXmlString('title', card.title));
+			});
+
+			it('should add content element of cards', async () => {
+				const { archive, contentElement } = await setup();
+				const manifest = getFileContent(archive, 'imsmanifest.xml');
+
+				expect(manifest).toContain(`<resource identifier="i${contentElement.id}"`);
 			});
 		});
 

--- a/apps/server/src/modules/learnroom/service/common-cartridge-export.service.spec.ts
+++ b/apps/server/src/modules/learnroom/service/common-cartridge-export.service.spec.ts
@@ -15,10 +15,10 @@ import {
 	lessonFactory,
 	setupEntities,
 	taskFactory,
+	richTextElementFactory,
 } from '@shared/testing';
 import { ColumnBoardService } from '@src/modules/board';
 import AdmZip from 'adm-zip';
-import { ContentElementFactory, ContentElementType } from '@shared/domain/domainobject';
 import { CommonCartridgeMapper } from '../mapper/common-cartridge.mapper';
 
 describe('CommonCartridgeExportService', () => {
@@ -29,7 +29,6 @@ describe('CommonCartridgeExportService', () => {
 	let taskServiceMock: DeepMocked<TaskService>;
 	let configServiceMock: DeepMocked<ConfigService<LearnroomConfig, true>>;
 	let columnBoardServiceMock: DeepMocked<ColumnBoardService>;
-	const contentElementFactory = new ContentElementFactory();
 
 	const createXmlString = (nodeName: string, value: boolean | number | string): string =>
 		`<${nodeName}>${value.toString()}</${nodeName}>`;
@@ -73,8 +72,8 @@ describe('CommonCartridgeExportService', () => {
 		});
 		const [lesson] = lessons;
 		const taskFromLesson = taskFactory.buildWithId({ course, lesson });
-		const contentElement = contentElementFactory.build(ContentElementType.RICH_TEXT);
-		const card = cardFactory.build({ children: [contentElement] });
+		const textCardElement = richTextElementFactory.build();
+		const card = cardFactory.build({ children: [textCardElement] });
 		const column = columnFactory.build({ children: [card] });
 		const columnBoard = columnBoardFactory.build({ children: [column] });
 
@@ -95,7 +94,7 @@ describe('CommonCartridgeExportService', () => {
 		);
 		const archive = new AdmZip(buffer);
 
-		return { archive, course, lessons, tasks, taskFromLesson, columnBoard, column, card, contentElement };
+		return { archive, course, lessons, tasks, taskFromLesson, columnBoard, column, card, textCardElement };
 	};
 
 	beforeAll(async () => {
@@ -265,10 +264,10 @@ describe('CommonCartridgeExportService', () => {
 			});
 
 			it('should add content element of cards', async () => {
-				const { archive, contentElement } = await setup();
+				const { archive, textCardElement } = await setup();
 				const manifest = getFileContent(archive, 'imsmanifest.xml');
 
-				expect(manifest).toContain(`<resource identifier="i${contentElement.id}"`);
+				expect(manifest).toContain(`<resource identifier="i${textCardElement.id}"`);
 			});
 		});
 

--- a/apps/server/src/modules/learnroom/service/common-cartridge-export.service.ts
+++ b/apps/server/src/modules/learnroom/service/common-cartridge-export.service.ts
@@ -6,7 +6,7 @@ import {
 import { LessonService } from '@modules/lesson';
 import { TaskService } from '@modules/task';
 import { Injectable } from '@nestjs/common';
-import { BoardExternalReferenceType, Column, Card } from '@shared/domain/domainobject';
+import { BoardExternalReferenceType, Column, Card, RichTextElement } from '@shared/domain/domainobject';
 import { ComponentProperties } from '@shared/domain/entity';
 import { EntityId } from '@shared/domain/types';
 import { ColumnBoardService } from '@src/modules/board';
@@ -129,10 +129,16 @@ export class CommonCartridgeExportService {
 
 	private addCardToOrganization(card: Card, organizationBuilder: CommonCartridgeOrganizationBuilder): void {
 		const { id } = card;
-		organizationBuilder.addSubOrganization({
+		const cardOrganization = organizationBuilder.addSubOrganization({
 			title: card.title,
 			identifier: createIdentifier(id),
 		});
+
+		card.children
+			.filter((child) => child instanceof RichTextElement /* || instanceof LinkElement */)
+			.forEach((child) =>
+				cardOrganization.addResource(this.commonCartridgeMapper.mapRichTextElementToResource(child as RichTextElement))
+			);
 	}
 
 	private addComponentToOrganization(

--- a/apps/server/src/modules/learnroom/service/common-cartridge-export.service.ts
+++ b/apps/server/src/modules/learnroom/service/common-cartridge-export.service.ts
@@ -135,7 +135,7 @@ export class CommonCartridgeExportService {
 		});
 
 		card.children
-			.filter((child) => child instanceof RichTextElement /* || instanceof LinkElement */)
+			.filter((child) => child instanceof RichTextElement)
 			.forEach((child) =>
 				cardOrganization.addResource(this.commonCartridgeMapper.mapRichTextElementToResource(child as RichTextElement))
 			);

--- a/apps/server/src/shared/testing/factory/domainobject/board/card.do.factory.ts
+++ b/apps/server/src/shared/testing/factory/domainobject/board/card.do.factory.ts
@@ -3,12 +3,12 @@ import { Card, CardProps } from '@shared/domain/domainobject';
 import { ObjectId } from '@mikro-orm/mongodb';
 import { BaseFactory } from '../../base.factory';
 
-export const cardFactory = BaseFactory.define<Card, CardProps>(Card, ({ sequence }) => {
+export const cardFactory = BaseFactory.define<Card, CardProps>(Card, ({ sequence, params }) => {
 	return {
 		id: new ObjectId().toHexString(),
 		title: `card #${sequence}`,
 		height: 150,
-		children: [],
+		children: params?.children || [],
 		createdAt: new Date(),
 		updatedAt: new Date(),
 	};


### PR DESCRIPTION
# Description
The common cartridge export was expanded to include rich text elements of the column board.

## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/EW-798

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review

- [x] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
