### PR TITLE
EW-799 Adding Column Board Link Element to Common Cartridge Export

### DIFF
--- a/apps/server/src/modules/learnroom/mapper/common-cartridge.mapper.ts
+++ b/apps/server/src/modules/learnroom/mapper/common-cartridge.mapper.ts
@@ -11,8 +11,8 @@ import {
 } from '@modules/common-cartridge';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { LinkElement, RichTextElement } from '@shared/domain/domainobject';
 import { ComponentProperties, ComponentType, Course, LessonEntity, Task } from '@shared/domain/entity';
-import { RichTextElement } from '@shared/domain/domainobject';
 import { LearnroomConfig } from '../learnroom.config';
 
 @Injectable()
@@ -126,6 +126,15 @@ export class CommonCartridgeMapper {
 			identifier: createIdentifier(element.id),
 			html: `<p>${element.text}</p>`,
 			intendedUse: CommonCartridgeIntendedUseType.UNSPECIFIED,
+		};
+	}
+
+	public mapLinkElementToResource(element: LinkElement): CommonCartridgeResourceProps {
+		return {
+			type: CommonCartridgeResourceType.WEB_LINK,
+			identifier: createIdentifier(element.id),
+			title: element.title,
+			url: element.url,
 		};
 	}
 


### PR DESCRIPTION
# Description
The Common Cartridge export of a course will now include the link elements from the column board cards.

## Links to Tickets or other pull requests
- <https://ticketsystem.dbildungscloud.de/browse/EW-799>

## Approval for review

- [ ] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
