### PR TITLE
BC-7337 - fix label from pod template from board-collaboration-deployment

### DIFF
--- a/ansible/roles/schulcloud-server-core/templates/board-collaboration-deployment.yml.j2
+++ b/ansible/roles/schulcloud-server-core/templates/board-collaboration-deployment.yml.j2
@@ -31,7 +31,7 @@ spec:
         app.kubernetes.io/part-of: schulcloud-verbund
         app.kubernetes.io/version: {{ SCHULCLOUD_SERVER_IMAGE_TAG }}
         app.kubernetes.io/name: board-collaboration
-        app.kubernetes.io/component: board-collaboration
+        app.kubernetes.io/component: server
         app.kubernetes.io/managed-by: ansible
         git.branch: {{ SCHULCLOUD_SERVER_BRANCH_NAME }}
         git.repo: {{ SCHULCLOUD_SERVER_REPO_NAME }}


### PR DESCRIPTION
# Description
The Label app.kubernetes.io/component form the pod template form board-collaboration-deployment was set to the wrong value 

## Links to Tickets or other pull requests
- https://ticketsystem.dbildungscloud.de/browse/BC-7337


## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review

- [x] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
