### PR TITLE
EW-863: Show error notification when account is not updated in keycloak

### DIFF
--- a/apps/server/src/modules/account/domain/services/account.service.spec.ts
+++ b/apps/server/src/modules/account/domain/services/account.service.spec.ts
@@ -27,7 +27,7 @@ import { AccountService } from './account.service';
 import { AccountValidationService } from './account.validation.service';
 import { AccountRepo } from '../../repo/micro-orm/account.repo';
 import { IdmCallbackLoggableException } from '../error';
-import { accountFactory } from '../../testing';
+import { accountDoFactory, accountFactory } from '../../testing';
 
 describe('AccountService', () => {
 	let module: TestingModule;
@@ -245,19 +245,18 @@ describe('AccountService', () => {
 			const setup = () => {
 				configService.get.mockReturnValue(true);
 
-				accountServiceDb.save.mockResolvedValueOnce({
-					getProps: () => {
-						return { id: '' };
-					},
-				} as Account);
+				const account = accountDoFactory.build();
 
-				return newAccountService();
+				accountServiceDb.save.mockResolvedValueOnce(account);
+				accountServiceIdm.save.mockResolvedValueOnce(account);
+
+				return { service: newAccountService(), account };
 			};
 
 			it('should call save in accountServiceIdm', async () => {
-				const service = setup();
+				const { service, account } = setup();
 
-				await expect(service.save({} as Account)).resolves.not.toThrow();
+				await expect(service.save(account)).resolves.not.toThrow();
 				expect(accountServiceIdm.save).toHaveBeenCalledTimes(1);
 			});
 		});
@@ -286,19 +285,37 @@ describe('AccountService', () => {
 		describe('when identity management is primary', () => {
 			const setup = () => {
 				configService.get.mockReturnValue(true);
-				accountServiceDb.save.mockResolvedValueOnce({
-					getProps: () => {
-						return { id: '' };
-					},
-				} as Account);
 
-				return newAccountService();
+				const account = accountDoFactory.build();
+
+				accountServiceDb.save.mockResolvedValueOnce(account);
+				accountServiceIdm.save.mockResolvedValueOnce(account);
+
+				return { service: newAccountService(), account };
 			};
 
 			it('should call idm implementation', async () => {
-				const service = setup();
-				await expect(service.save({ username: 'username' } as AccountSave)).resolves.not.toThrow();
+				const { service, account } = setup();
+				await expect(service.save(account)).resolves.not.toThrow();
 				expect(accountServiceIdm.save).toHaveBeenCalledTimes(1);
+			});
+		});
+
+		describe(`when identity management is primary and can't update account`, () => {
+			const setup = () => {
+				configService.get.mockReturnValue(true);
+
+				const account = accountDoFactory.build();
+
+				accountServiceDb.save.mockResolvedValueOnce(account);
+				accountServiceIdm.save.mockImplementation(() => Promise.reject(new Error()));
+
+				return { service: newAccountService(), account };
+			};
+
+			it('should throw ValidationError', async () => {
+				const { service, account } = setup();
+				await expect(service.save(account)).rejects.toThrow(ValidationError);
 			});
 		});
 	});
@@ -432,21 +449,23 @@ describe('AccountService', () => {
 		describe('When identity management is primary', () => {
 			const setup = () => {
 				configService.get.mockReturnValue(true);
-				accountServiceDb.save.mockResolvedValueOnce({
-					getProps: () => {
-						return { id: '' };
-					},
-				} as Account);
+
+				const account = accountDoFactory.build({
+					password: defaultPasswordHash,
+					username: 'username@mail.tld',
+				});
+
+				accountServiceDb.save.mockResolvedValueOnce(account);
+				accountServiceIdm.save.mockResolvedValueOnce(account);
+
 				accountValidationService.isUniqueEmail.mockResolvedValueOnce(true);
 
-				return newAccountService();
+				return { service: newAccountService(), account };
 			};
 
 			it('should call idm implementation', async () => {
-				const service = setup();
-				await expect(
-					service.saveWithValidation({ username: 'username@mail.tld', password: 'Password_123' } as AccountSave)
-				).resolves.not.toThrow();
+				const { service, account } = setup();
+				await expect(service.saveWithValidation(account)).resolves.not.toThrow();
 				expect(accountServiceIdm.save).toHaveBeenCalledTimes(1);
 			});
 		});
@@ -1295,6 +1314,39 @@ describe('AccountService', () => {
 						email: 'fail@to.update',
 					})
 				).rejects.toThrow(EntityNotFoundError);
+			});
+		});
+
+		describe('When save throws ValidationError', () => {
+			const setup = () => {
+				const mockSchool = schoolEntityFactory.buildWithId();
+
+				const mockStudentUser = userFactory.buildWithId({
+					school: mockSchool,
+				});
+				const mockStudentAccount = accountFactory.buildWithId({
+					userId: mockStudentUser.id,
+					password: defaultPasswordHash,
+				});
+				const mockStudentAccountDo: Account = AccountEntityToDoMapper.mapToDo(mockStudentAccount);
+
+				userRepo.save.mockResolvedValueOnce(undefined);
+				accountServiceDb.validatePassword.mockResolvedValue(true);
+				accountServiceDb.save.mockRejectedValueOnce(new ValidationError('fail to update'));
+
+				accountValidationService.isUniqueEmail.mockResolvedValue(true);
+
+				return { mockStudentUser, mockStudentAccountDo };
+			};
+
+			it('should rethrow ValidationError', async () => {
+				const { mockStudentUser, mockStudentAccountDo } = setup();
+				await expect(
+					accountService.updateMyAccount(mockStudentUser, mockStudentAccountDo, {
+						passwordOld: defaultPassword,
+						email: 'fail@to.update',
+					})
+				).rejects.toThrow(ValidationError);
 			});
 		});
 	});

--- a/apps/server/src/modules/account/domain/services/account.service.spec.ts
+++ b/apps/server/src/modules/account/domain/services/account.service.spec.ts
@@ -318,6 +318,26 @@ describe('AccountService', () => {
 				await expect(service.save(account)).rejects.toThrow(ValidationError);
 			});
 		});
+
+		describe(`when identity management is primary and can't update username`, () => {
+			const setup = () => {
+				configService.get.mockReturnValue(true);
+
+				const account = accountDoFactory.build();
+
+				accountServiceDb.save.mockResolvedValueOnce(account);
+				accountServiceIdm.save.mockImplementation(() =>
+					Promise.resolve(new Account({ username: 'otherUsername', id: '' }))
+				);
+
+				return { service: newAccountService(), account };
+			};
+
+			it('should throw ValidationError', async () => {
+				const { service, account } = setup();
+				await expect(service.save(account)).rejects.toThrow(ValidationError);
+			});
+		});
 	});
 
 	describe('saveWithValidation', () => {

--- a/apps/server/src/modules/account/domain/services/account.service.ts
+++ b/apps/server/src/modules/account/domain/services/account.service.ts
@@ -287,7 +287,7 @@ export class AccountService extends AbstractAccountService implements DeletionSe
 		});
 
 		if (this.configService.get('FEATURE_IDENTITY_MANAGEMENT_STORE_ENABLED') === true) {
-			if (idmAccount === null || idmAccount.username !== accountSave.username) {
+			if (idmAccount === null || (accountSave.username && idmAccount.username !== accountSave.username)) {
 				throw new ValidationError('Account could not be updated');
 			}
 		}

--- a/apps/server/src/modules/account/domain/services/account.service.ts
+++ b/apps/server/src/modules/account/domain/services/account.service.ts
@@ -273,7 +273,7 @@ export class AccountService extends AbstractAccountService implements DeletionSe
 		});
 
 		if (this.configService.get('FEATURE_IDENTITY_MANAGEMENT_STORE_ENABLED') === true) {
-			if (idmAccount === null || idmAccount?.username !== accountSave.username) {
+			if (idmAccount === null || idmAccount.username !== accountSave.username) {
 				throw new ValidationError('Account could not be updated');
 			}
 		}


### PR DESCRIPTION
# Description
Show an error notification to the user when the keycloak account could not be updated.

## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/EW-863

## Approval for review

- [x] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
