### PR TITLE
BC-7298 - refactor failure actions

### DIFF
--- a/apps/server/src/modules/board/gateway/api-test/board-collaboration.gateway.spec.ts
+++ b/apps/server/src/modules/board/gateway/api-test/board-collaboration.gateway.spec.ts
@@ -18,7 +18,6 @@ import { getSocketApiClient, waitForEvent } from '@shared/testing/test-socket-ap
 import { Socket } from 'socket.io-client';
 import { BoardCollaborationTestingModule } from '../../board-collaboration.testing.module';
 import { BoardCollaborationGateway } from '../board-collaboration.gateway';
-import { BoardObjectType, ErrorType } from '../types';
 
 describe(BoardCollaborationGateway.name, () => {
 	let app: INestApplication;
@@ -107,11 +106,7 @@ describe(BoardCollaborationGateway.name, () => {
 				ioClient.emit('create-card-request', { columnId });
 				const failure = await waitForEvent(ioClient, 'create-card-failure');
 
-				expect(failure).toEqual({
-					boardObjectType: BoardObjectType.BOARD_CARD,
-					errorType: ErrorType.NOT_CREATED,
-					requestPayload: { columnId },
-				});
+				expect(failure).toEqual({ columnId });
 			});
 		});
 	});
@@ -137,11 +132,7 @@ describe(BoardCollaborationGateway.name, () => {
 				ioClient.emit('fetch-board-request', { boardId });
 				const failure = await waitForEvent(ioClient, 'fetch-board-failure');
 
-				expect(failure).toEqual({
-					boardObjectType: BoardObjectType.BOARD,
-					errorType: ErrorType.NOT_LOADED,
-					requestPayload: { boardId },
-				});
+				expect(failure).toEqual({ boardId });
 			});
 		});
 	});
@@ -206,11 +197,7 @@ describe(BoardCollaborationGateway.name, () => {
 				ioClient.emit('move-card-request', moveCardProps);
 				const failure = await waitForEvent(ioClient, 'move-card-failure');
 
-				expect(failure).toEqual({
-					boardObjectType: BoardObjectType.BOARD_CARD,
-					errorType: ErrorType.NOT_UPDATED,
-					requestPayload: moveCardProps,
-				});
+				expect(failure).toEqual(moveCardProps);
 			});
 		});
 	});
@@ -235,11 +222,7 @@ describe(BoardCollaborationGateway.name, () => {
 				ioClient.emit('update-column-title-request', updateColumnProps);
 				const failure = await waitForEvent(ioClient, 'update-column-title-failure');
 
-				expect(failure).toEqual({
-					boardObjectType: BoardObjectType.BOARD_COLUMN,
-					errorType: ErrorType.NOT_UPDATED,
-					requestPayload: updateColumnProps,
-				});
+				expect(failure).toEqual(updateColumnProps);
 			});
 		});
 	});
@@ -260,16 +243,12 @@ describe(BoardCollaborationGateway.name, () => {
 		describe('when board does not exist', () => {
 			it('should answer with failure', async () => {
 				await setup();
-				const boardId = new ObjectId().toHexString();
+				const payload = { boardId: new ObjectId().toHexString() };
 
-				ioClient.emit('delete-board-request', { boardId });
+				ioClient.emit('delete-board-request', payload);
 				const failure = await waitForEvent(ioClient, 'delete-board-failure');
 
-				expect(failure).toEqual({
-					boardObjectType: BoardObjectType.BOARD,
-					errorType: ErrorType.NOT_DELETED,
-					requestPayload: { boardId },
-				});
+				expect(failure).toEqual(payload);
 			});
 		});
 	});
@@ -290,17 +269,13 @@ describe(BoardCollaborationGateway.name, () => {
 		describe('when board does not exist', () => {
 			it('should answer with failure', async () => {
 				await setup();
-				const updateTitleProps = { boardId: new ObjectId().toHexString(), newTitle: 'new title' };
+				const payload = { boardId: new ObjectId().toHexString(), newTitle: 'new title' };
 
-				ioClient.emit('update-board-title-request', updateTitleProps);
+				ioClient.emit('update-board-title-request', payload);
 				const failure = await waitForEvent(ioClient, 'update-board-title-failure');
 
 				expect(failure).toBeDefined();
-				expect(failure).toEqual({
-					boardObjectType: BoardObjectType.BOARD,
-					errorType: ErrorType.NOT_UPDATED,
-					requestPayload: updateTitleProps,
-				});
+				expect(failure).toEqual(payload);
 			});
 		});
 	});
@@ -321,16 +296,12 @@ describe(BoardCollaborationGateway.name, () => {
 		describe('when board does not exist', () => {
 			it('should answer with failure', async () => {
 				await setup();
-				const boardId = new ObjectId().toHexString();
+				const payload = { boardId: new ObjectId().toHexString() };
 
-				ioClient.emit('create-column-request', { boardId });
+				ioClient.emit('create-column-request', payload);
 				const failure = await waitForEvent(ioClient, 'create-column-failure');
 
-				expect(failure).toEqual({
-					boardObjectType: BoardObjectType.BOARD_COLUMN,
-					errorType: ErrorType.NOT_CREATED,
-					requestPayload: { boardId },
-				});
+				expect(failure).toEqual(payload);
 			});
 		});
 	});
@@ -356,11 +327,7 @@ describe(BoardCollaborationGateway.name, () => {
 				ioClient.emit('update-board-visibility-request', { boardId, isVisible: false });
 				const failure = await waitForEvent(ioClient, 'update-board-visibility-failure');
 
-				expect(failure).toEqual({
-					boardObjectType: BoardObjectType.BOARD,
-					errorType: ErrorType.NOT_UPDATED,
-					requestPayload: { boardId, isVisible: false },
-				});
+				expect(failure).toEqual({ boardId, isVisible: false });
 			});
 		});
 	});
@@ -386,11 +353,7 @@ describe(BoardCollaborationGateway.name, () => {
 				ioClient.emit('delete-column-request', { columnId });
 				const failure = await waitForEvent(ioClient, 'delete-column-failure');
 
-				expect(failure).toEqual({
-					boardObjectType: BoardObjectType.BOARD_COLUMN,
-					errorType: ErrorType.NOT_DELETED,
-					requestPayload: { columnId },
-				});
+				expect(failure).toEqual({ columnId });
 			});
 		});
 	});
@@ -400,7 +363,7 @@ describe(BoardCollaborationGateway.name, () => {
 			it('should answer with success', async () => {
 				const { columnBoardNode, columnNode } = await setup();
 
-				const moveColumnProps = {
+				const payload = {
 					targetBoardId: columnBoardNode.id,
 					columnMove: {
 						addedIndex: 1,
@@ -409,10 +372,10 @@ describe(BoardCollaborationGateway.name, () => {
 					},
 				};
 
-				ioClient.emit('move-column-request', moveColumnProps);
+				ioClient.emit('move-column-request', payload);
 				const success = await waitForEvent(ioClient, 'move-column-success');
 
-				expect(success).toEqual(expect.objectContaining(moveColumnProps));
+				expect(success).toEqual(expect.objectContaining(payload));
 			});
 		});
 
@@ -420,7 +383,7 @@ describe(BoardCollaborationGateway.name, () => {
 			it('should answer with failure', async () => {
 				const { columnBoardNode } = await setup();
 
-				const moveColumnProps = {
+				const payload = {
 					targetBoardId: columnBoardNode.id,
 					columnMove: {
 						addedIndex: 1,
@@ -429,14 +392,10 @@ describe(BoardCollaborationGateway.name, () => {
 					},
 				};
 
-				ioClient.emit('move-column-request', moveColumnProps);
+				ioClient.emit('move-column-request', payload);
 				const failure = await waitForEvent(ioClient, 'move-column-failure');
 
-				expect(failure).toEqual({
-					boardObjectType: BoardObjectType.BOARD_COLUMN,
-					errorType: ErrorType.NOT_UPDATED,
-					requestPayload: moveColumnProps,
-				});
+				expect(failure).toEqual(payload);
 			});
 		});
 	});
@@ -457,16 +416,12 @@ describe(BoardCollaborationGateway.name, () => {
 		describe('when card does not exist', () => {
 			it('should answer with failure', async () => {
 				await setup();
-				const updateCardTitleProps = { cardId: new ObjectId().toHexString(), newTitle: 'new title' };
+				const payload = { cardId: new ObjectId().toHexString(), newTitle: 'new title' };
 
-				ioClient.emit('update-card-title-request', updateCardTitleProps);
+				ioClient.emit('update-card-title-request', payload);
 				const failure = await waitForEvent(ioClient, 'update-card-title-failure');
 
-				expect(failure).toEqual({
-					boardObjectType: BoardObjectType.BOARD_CARD,
-					errorType: ErrorType.NOT_UPDATED,
-					requestPayload: updateCardTitleProps,
-				});
+				expect(failure).toEqual(payload);
 			});
 		});
 	});
@@ -488,16 +443,12 @@ describe(BoardCollaborationGateway.name, () => {
 		describe('when card does not exist', () => {
 			it('should answer with failure', async () => {
 				await setup();
-				const updateCardHeightProps = { cardId: new ObjectId().toHexString(), newHeight: 200 };
+				const payload = { cardId: new ObjectId().toHexString(), newHeight: 200 };
 
-				ioClient.emit('update-card-height-request', updateCardHeightProps);
+				ioClient.emit('update-card-height-request', payload);
 				const failure = await waitForEvent(ioClient, 'update-card-height-failure');
 
-				expect(failure).toEqual({
-					boardObjectType: BoardObjectType.BOARD_CARD,
-					errorType: ErrorType.NOT_UPDATED,
-					requestPayload: updateCardHeightProps,
-				});
+				expect(failure).toEqual(payload);
 			});
 		});
 	});
@@ -518,16 +469,12 @@ describe(BoardCollaborationGateway.name, () => {
 		describe('when card does not exist', () => {
 			it('should answer with failure', async () => {
 				await setup();
-				const cardId = new ObjectId().toHexString();
+				const payload = { cardIds: [new ObjectId().toHexString()] };
 
-				ioClient.emit('fetch-card-request', { cardIds: [cardId] });
+				ioClient.emit('fetch-card-request', payload);
 				const failure = await waitForEvent(ioClient, 'fetch-card-failure');
 
-				expect(failure).toEqual({
-					boardObjectType: BoardObjectType.BOARD_CARD,
-					errorType: ErrorType.NOT_LOADED,
-					requestPayload: { cardIds: [cardId] },
-				});
+				expect(failure).toEqual(payload);
 			});
 		});
 	});
@@ -548,16 +495,12 @@ describe(BoardCollaborationGateway.name, () => {
 		describe('when card does not exist', () => {
 			it('should answer with failure', async () => {
 				await setup();
-				const cardId = new ObjectId().toHexString();
+				const payload = { cardId: new ObjectId().toHexString() };
 
-				ioClient.emit('delete-card-request', { cardId });
+				ioClient.emit('delete-card-request', payload);
 				const failure = await waitForEvent(ioClient, 'delete-card-failure');
 
-				expect(failure).toEqual({
-					boardObjectType: BoardObjectType.BOARD_CARD,
-					errorType: ErrorType.NOT_DELETED,
-					requestPayload: { cardId },
-				});
+				expect(failure).toEqual(payload);
 			});
 		});
 	});
@@ -581,14 +524,12 @@ describe(BoardCollaborationGateway.name, () => {
 				await setup();
 				const cardId = new ObjectId().toHexString();
 
-				ioClient.emit('create-element-request', { cardId, type: ContentElementType.RICH_TEXT });
+				const payload = { cardId, type: ContentElementType.RICH_TEXT };
+
+				ioClient.emit('create-element-request', payload);
 				const failure = await waitForEvent(ioClient, 'create-element-failure');
 
-				expect(failure).toEqual({
-					boardObjectType: BoardObjectType.BOARD_ELEMENT,
-					errorType: ErrorType.NOT_CREATED,
-					requestPayload: { cardId, type: ContentElementType.RICH_TEXT },
-				});
+				expect(failure).toEqual(payload);
 			});
 		});
 	});
@@ -610,16 +551,12 @@ describe(BoardCollaborationGateway.name, () => {
 		describe('when element does not exist', () => {
 			it('should answer with failure', async () => {
 				const { cardNodes } = await setup();
-				const deleteElementProps = { cardId: cardNodes[0].id, elementId: new ObjectId().toHexString() };
+				const payload = { cardId: cardNodes[0].id, elementId: new ObjectId().toHexString() };
 
-				ioClient.emit('delete-element-request', deleteElementProps);
+				ioClient.emit('delete-element-request', payload);
 				const failure = await waitForEvent(ioClient, 'delete-element-failure');
 
-				expect(failure).toEqual({
-					boardObjectType: BoardObjectType.BOARD_ELEMENT,
-					errorType: ErrorType.NOT_DELETED,
-					requestPayload: deleteElementProps,
-				});
+				expect(failure).toEqual(payload);
 			});
 		});
 	});
@@ -648,7 +585,7 @@ describe(BoardCollaborationGateway.name, () => {
 		describe('when element does not exist', () => {
 			it('should answer with failure', async () => {
 				await setup();
-				const updateElementProps = {
+				const payload = {
 					elementId: new ObjectId().toHexString(),
 					data: {
 						type: ContentElementType.RICH_TEXT,
@@ -656,14 +593,10 @@ describe(BoardCollaborationGateway.name, () => {
 					},
 				};
 
-				ioClient.emit('update-element-request', updateElementProps);
+				ioClient.emit('update-element-request', payload);
 				const failure = await waitForEvent(ioClient, 'update-element-failure');
 
-				expect(failure).toEqual({
-					boardObjectType: BoardObjectType.BOARD_ELEMENT,
-					errorType: ErrorType.NOT_UPDATED,
-					requestPayload: updateElementProps,
-				});
+				expect(failure).toEqual(payload);
 			});
 		});
 	});
@@ -672,28 +605,24 @@ describe(BoardCollaborationGateway.name, () => {
 		describe('when element exists', () => {
 			it('should answer with success', async () => {
 				const { cardNodes, elementNodes } = await setup();
-				const data = { elementId: elementNodes[0].id, toCardId: cardNodes[0].id, toPosition: 2 };
+				const payload = { elementId: elementNodes[0].id, toCardId: cardNodes[0].id, toPosition: 2 };
 
-				ioClient.emit('move-element-request', data);
+				ioClient.emit('move-element-request', payload);
 				const success = await waitForEvent(ioClient, 'move-element-success');
 
-				expect(success).toEqual(expect.objectContaining(data));
+				expect(success).toEqual(expect.objectContaining(payload));
 			});
 		});
 
 		describe('when element does not exist', () => {
 			it('should answer with failure', async () => {
 				const { cardNodes } = await setup();
-				const data = { elementId: new ObjectId().toHexString(), toCardId: cardNodes[0].id, toPosition: 2 };
+				const payload = { elementId: new ObjectId().toHexString(), toCardId: cardNodes[0].id, toPosition: 2 };
 
-				ioClient.emit('move-element-request', data);
+				ioClient.emit('move-element-request', payload);
 				const failure = await waitForEvent(ioClient, 'move-element-failure');
 
-				expect(failure).toEqual({
-					boardObjectType: BoardObjectType.BOARD_ELEMENT,
-					errorType: ErrorType.NOT_UPDATED,
-					requestPayload: data,
-				});
+				expect(failure).toEqual(payload);
 			});
 		});
 	});

--- a/apps/server/src/modules/board/gateway/board-collaboration.gateway.ts
+++ b/apps/server/src/modules/board/gateway/board-collaboration.gateway.ts
@@ -29,7 +29,6 @@ import { UpdateBoardVisibilityMessageParams } from './dto/update-board-visibilit
 import { UpdateCardHeightMessageParams } from './dto/update-card-height.message.param';
 import { UpdateCardTitleMessageParams } from './dto/update-card-title.message.param';
 import { UpdateContentElementMessageParams } from './dto/update-content-element.message.param';
-import { BoardObjectType, ErrorType } from './types';
 
 @UsePipes(new WsValidationPipe())
 @WebSocketGateway(BoardCollaborationConfiguration.websocket)
@@ -67,11 +66,7 @@ export class BoardCollaborationGateway {
 			client.to(room).emit('delete-board-success', { ...data, isOwnAction: false });
 			client.emit('delete-board-success', { ...data, isOwnAction: true });
 		} catch (err) {
-			client.emit('delete-board-failure', {
-				boardObjectType: BoardObjectType.BOARD,
-				errorType: ErrorType.NOT_DELETED,
-				requestPayload: data,
-			});
+			client.emit('delete-board-failure', data);
 		}
 	}
 
@@ -86,11 +81,7 @@ export class BoardCollaborationGateway {
 			client.to(room).emit('update-board-title-success', { ...data, isOwnAction: false });
 			client.emit('update-board-title-success', { ...data, isOwnAction: true });
 		} catch (err) {
-			client.emit('update-board-title-failure', {
-				boardObjectType: BoardObjectType.BOARD,
-				errorType: ErrorType.NOT_UPDATED,
-				requestPayload: data,
-			});
+			client.emit('update-board-title-failure', data);
 		}
 	}
 
@@ -105,11 +96,7 @@ export class BoardCollaborationGateway {
 			client.to(room).emit('update-card-title-success', { ...data, isOwnAction: false });
 			client.emit('update-card-title-success', { ...data, isOwnAction: true });
 		} catch (err) {
-			client.emit('update-card-title-failure', {
-				boardObjectType: BoardObjectType.BOARD_CARD,
-				errorType: ErrorType.NOT_UPDATED,
-				requestPayload: data,
-			});
+			client.emit('update-card-title-failure', data);
 		}
 	}
 
@@ -124,11 +111,7 @@ export class BoardCollaborationGateway {
 			client.to(room).emit('update-card-height-success', { ...data, isOwnAction: false });
 			client.emit('update-card-height-success', { ...data, isOwnAction: true });
 		} catch (err) {
-			client.emit('update-card-height-failure', {
-				boardObjectType: BoardObjectType.BOARD_CARD,
-				errorType: ErrorType.NOT_UPDATED,
-				requestPayload: data,
-			});
+			client.emit('update-card-height-failure', data);
 		}
 	}
 
@@ -143,11 +126,7 @@ export class BoardCollaborationGateway {
 			client.to(room).emit('delete-card-success', { ...data, isOwnAction: false });
 			client.emit('delete-card-success', { ...data, isOwnAction: true });
 		} catch (err) {
-			client.emit('delete-card-failure', {
-				boardObjectType: BoardObjectType.BOARD_CARD,
-				errorType: ErrorType.NOT_DELETED,
-				requestPayload: data,
-			});
+			client.emit('delete-card-failure', data);
 		}
 	}
 
@@ -166,11 +145,7 @@ export class BoardCollaborationGateway {
 			client.to(room).emit('create-card-success', { ...responsePayload, isOwnAction: false });
 			client.emit('create-card-success', { ...responsePayload, isOwnAction: true });
 		} catch (err) {
-			client.emit('create-card-failure', {
-				boardObjectType: BoardObjectType.BOARD_CARD,
-				errorType: ErrorType.NOT_CREATED,
-				requestPayload: data,
-			});
+			client.emit('create-card-failure', data);
 		}
 	}
 
@@ -194,11 +169,7 @@ export class BoardCollaborationGateway {
 			// of createColumn and move the card into that column
 			return responsePayload;
 		} catch (err) {
-			client.emit('create-column-failure', {
-				boardObjectType: BoardObjectType.BOARD_COLUMN,
-				errorType: ErrorType.NOT_CREATED,
-				requestPayload: data,
-			});
+			client.emit('create-column-failure', data);
 			return {};
 		}
 	}
@@ -214,11 +185,7 @@ export class BoardCollaborationGateway {
 
 			client.emit('fetch-board-success', responsePayload);
 		} catch (err) {
-			client.emit('fetch-board-failure', {
-				boardObjectType: BoardObjectType.BOARD,
-				errorType: ErrorType.NOT_LOADED,
-				requestPayload: data,
-			});
+			client.emit('fetch-board-failure', data);
 		}
 	}
 
@@ -233,11 +200,7 @@ export class BoardCollaborationGateway {
 			client.to(room).emit('move-card-success', { ...data, isOwnAction: false });
 			client.emit('move-card-success', { ...data, isOwnAction: true });
 		} catch (err) {
-			client.emit('move-card-failure', {
-				boardObjectType: BoardObjectType.BOARD_CARD,
-				errorType: ErrorType.NOT_UPDATED,
-				requestPayload: data,
-			});
+			client.emit('move-card-failure', data);
 		}
 	}
 
@@ -252,11 +215,7 @@ export class BoardCollaborationGateway {
 			client.to(room).emit('move-column-success', { ...data, isOwnAction: false });
 			client.emit('move-column-success', { ...data, isOwnAction: true });
 		} catch (err) {
-			client.emit('move-column-failure', {
-				boardObjectType: BoardObjectType.BOARD_COLUMN,
-				errorType: ErrorType.NOT_UPDATED,
-				requestPayload: data,
-			});
+			client.emit('move-column-failure', data);
 		}
 	}
 
@@ -271,11 +230,7 @@ export class BoardCollaborationGateway {
 			client.to(room).emit('update-column-title-success', { ...data, isOwnAction: false });
 			client.emit('update-column-title-success', { ...data, isOwnAction: true });
 		} catch (err) {
-			client.emit('update-column-title-failure', {
-				boardObjectType: BoardObjectType.BOARD_COLUMN,
-				errorType: ErrorType.NOT_UPDATED,
-				requestPayload: data,
-			});
+			client.emit('update-column-title-failure', data);
 		}
 	}
 
@@ -290,11 +245,7 @@ export class BoardCollaborationGateway {
 			client.to(room).emit('update-board-visibility-success', { ...data, isOwnAction: false });
 			client.emit('update-board-visibility-success', { ...data, isOwnAction: true });
 		} catch (err) {
-			client.emit('update-board-visibility-failure', {
-				boardObjectType: BoardObjectType.BOARD,
-				errorType: ErrorType.NOT_UPDATED,
-				requestPayload: data,
-			});
+			client.emit('update-board-visibility-failure', data);
 		}
 	}
 
@@ -309,11 +260,7 @@ export class BoardCollaborationGateway {
 			client.to(room).emit('delete-column-success', { ...data, isOwnAction: false });
 			client.emit('delete-column-success', { ...data, isOwnAction: true });
 		} catch (err) {
-			client.emit('delete-column-failure', {
-				boardObjectType: BoardObjectType.BOARD_COLUMN,
-				errorType: ErrorType.NOT_DELETED,
-				requestPayload: data,
-			});
+			client.emit('delete-column-failure', data);
 		}
 	}
 
@@ -328,11 +275,7 @@ export class BoardCollaborationGateway {
 			await this.ensureUserInRoom(client, data.cardIds[0]);
 			client.emit('fetch-card-success', { cards: cardResponses, isOwnAction: true });
 		} catch (err) {
-			client.emit('fetch-card-failure', {
-				boardObjectType: BoardObjectType.BOARD_CARD,
-				errorType: ErrorType.NOT_LOADED,
-				requestPayload: data,
-			});
+			client.emit('fetch-card-failure', data);
 		}
 	}
 
@@ -351,11 +294,7 @@ export class BoardCollaborationGateway {
 			client.to(room).emit('create-element-success', { ...responsePayload, isOwnAction: false });
 			client.emit('create-element-success', { ...responsePayload, isOwnAction: true });
 		} catch (err) {
-			client.emit('create-element-failure', {
-				boardObjectType: BoardObjectType.BOARD_ELEMENT,
-				errorType: ErrorType.NOT_CREATED,
-				requestPayload: data,
-			});
+			client.emit('create-element-failure', data);
 		}
 	}
 
@@ -370,11 +309,7 @@ export class BoardCollaborationGateway {
 			client.to(room).emit('update-element-success', { ...data, isOwnAction: false });
 			client.emit('update-element-success', { ...data, isOwnAction: true });
 		} catch (err) {
-			client.emit('update-element-failure', {
-				boardObjectType: BoardObjectType.BOARD_ELEMENT,
-				errorType: ErrorType.NOT_UPDATED,
-				requestPayload: data,
-			});
+			client.emit('update-element-failure', data);
 		}
 	}
 
@@ -389,11 +324,7 @@ export class BoardCollaborationGateway {
 			client.to(room).emit('delete-element-success', { ...data, isOwnAction: false });
 			client.emit('delete-element-success', { ...data, isOwnAction: true });
 		} catch (err) {
-			client.emit('delete-element-failure', {
-				boardObjectType: BoardObjectType.BOARD_ELEMENT,
-				errorType: ErrorType.NOT_DELETED,
-				requestPayload: data,
-			});
+			client.emit('delete-element-failure', data);
 		}
 	}
 
@@ -408,11 +339,7 @@ export class BoardCollaborationGateway {
 			client.to(room).emit('move-element-success', { ...data, isOwnAction: false });
 			client.emit('move-element-success', { ...data, isOwnAction: true });
 		} catch (err) {
-			client.emit('move-element-failure', {
-				boardObjectType: BoardObjectType.BOARD_ELEMENT,
-				errorType: ErrorType.NOT_UPDATED,
-				requestPayload: data,
-			});
+			client.emit('move-element-failure', data);
 		}
 	}
 


### PR DESCRIPTION
# Description
Simplify all Failure-Action payloads to no longer carry ErrorType and BoardNodeType in order simplify failure-structure and to remove redundancy between action-name and carried data. This way refactorings on the backend-side are enabled

## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/BC-7298
https://github.com/hpi-schul-cloud/nuxt-client/pull/3273

## Approval for review

- [x] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
