### PR TITLE
BC-7236 - refactor how to get rootid in socket gateway

### DIFF
--- a/apps/server/src/modules/board/gateway/board-collaboration.gateway.ts
+++ b/apps/server/src/modules/board/gateway/board-collaboration.gateway.ts
@@ -41,6 +41,7 @@ import { UpdateBoardVisibilityMessageParams } from './dto/update-board-visibilit
 import { UpdateCardHeightMessageParams } from './dto/update-card-height.message.param';
 import { UpdateCardTitleMessageParams } from './dto/update-card-title.message.param';
 import { UpdateContentElementMessageParams } from './dto/update-content-element.message.param';
+import { AnyBoardNode, BoardNode } from '../domain';
 
 @UsePipes(new WsValidationPipe())
 @WebSocketGateway(BoardCollaborationConfiguration.websocket)
@@ -88,12 +89,12 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 	@SubscribeMessage('delete-board-request')
 	@UseRequestContext()
 	async deleteBoard(socket: Socket, data: DeleteBoardMessageParams) {
-		const emitter = await this.buildBoardSocketEmitter({ socket, id: data.boardId, action: 'delete-board' });
+		const emitter = await this.buildBoardSocketEmitter({ socket, action: 'delete-board' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
-			await this.boardUc.deleteBoard(userId, data.boardId);
+			const result = await this.boardUc.deleteBoard(userId, data.boardId);
 
-			await emitter.emitToClientAndRoom(data);
+			await emitter.emitToClientAndRoom(data, result);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -104,12 +105,12 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 	@TrackExecutionTime()
 	@UseRequestContext()
 	async updateBoardTitle(socket: Socket, data: UpdateBoardTitleMessageParams) {
-		const emitter = await this.buildBoardSocketEmitter({ socket, id: data.boardId, action: 'update-board-title' });
+		const emitter = await this.buildBoardSocketEmitter({ socket, action: 'update-board-title' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
-			await this.boardUc.updateBoardTitle(userId, data.boardId, data.newTitle);
+			const result = await this.boardUc.updateBoardTitle(userId, data.boardId, data.newTitle);
 
-			await emitter.emitToClientAndRoom(data);
+			await emitter.emitToClientAndRoom(data, result);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -120,12 +121,12 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 	@TrackExecutionTime()
 	@UseRequestContext()
 	async updateCardTitle(socket: Socket, data: UpdateCardTitleMessageParams) {
-		const emitter = await this.buildBoardSocketEmitter({ socket, id: data.cardId, action: 'update-card-title' });
+		const emitter = await this.buildBoardSocketEmitter({ socket, action: 'update-card-title' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
-			await this.cardUc.updateCardTitle(userId, data.cardId, data.newTitle);
+			const result = await this.cardUc.updateCardTitle(userId, data.cardId, data.newTitle);
 
-			await emitter.emitToClientAndRoom(data);
+			await emitter.emitToClientAndRoom(data, result);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -135,12 +136,12 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 	@SubscribeMessage('update-card-height-request')
 	@UseRequestContext()
 	async updateCardHeight(socket: Socket, data: UpdateCardHeightMessageParams) {
-		const emitter = await this.buildBoardSocketEmitter({ socket, id: data.cardId, action: 'update-card-height' });
+		const emitter = await this.buildBoardSocketEmitter({ socket, action: 'update-card-height' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
-			await this.cardUc.updateCardHeight(userId, data.cardId, data.newHeight);
+			const result = await this.cardUc.updateCardHeight(userId, data.cardId, data.newHeight);
 
-			await emitter.emitToClientAndRoom(data);
+			await emitter.emitToClientAndRoom(data, result);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -150,12 +151,12 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 	@SubscribeMessage('delete-card-request')
 	@UseRequestContext()
 	async deleteCard(socket: Socket, data: DeleteCardMessageParams) {
-		const emitter = await this.buildBoardSocketEmitter({ socket, id: data.cardId, action: 'delete-card' });
+		const emitter = await this.buildBoardSocketEmitter({ socket, action: 'delete-card' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
-			await this.cardUc.deleteCard(userId, data.cardId);
+			const result = await this.cardUc.deleteCard(userId, data.cardId);
 
-			await emitter.emitToClientAndRoom(data);
+			await emitter.emitToClientAndRoom(data, result);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -166,7 +167,7 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 	@TrackExecutionTime()
 	@UseRequestContext()
 	async createCard(socket: Socket, data: CreateCardMessageParams) {
-		const emitter = await this.buildBoardSocketEmitter({ socket, id: data.columnId, action: 'create-card' });
+		const emitter = await this.buildBoardSocketEmitter({ socket, action: 'create-card' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
 			const card = await this.columnUc.createCard(userId, data.columnId);
@@ -177,7 +178,7 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 				newCard,
 			};
 
-			await emitter.emitToClientAndRoom(responsePayload);
+			await emitter.emitToClientAndRoom(responsePayload, card);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -187,7 +188,7 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 	@SubscribeMessage('create-column-request')
 	@UseRequestContext()
 	async createColumn(socket: Socket, data: CreateColumnMessageParams) {
-		const emitter = await this.buildBoardSocketEmitter({ socket, id: data.boardId, action: 'create-column' });
+		const emitter = await this.buildBoardSocketEmitter({ socket, action: 'create-column' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
 			const column = await this.boardUc.createColumn(userId, data.boardId);
@@ -197,7 +198,7 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 				...data,
 				newColumn,
 			};
-			await emitter.emitToClientAndRoom(responsePayload);
+			await emitter.emitToClientAndRoom(responsePayload, column);
 
 			// payload needs to be returned to allow the client to do sequential operation
 			// of createColumn and move the card into that column
@@ -212,12 +213,13 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 	@TrackExecutionTime()
 	@UseRequestContext()
 	async fetchBoard(socket: Socket, data: FetchBoardMessageParams) {
-		const emitter = await this.buildBoardSocketEmitter({ socket, id: data.boardId, action: 'fetch-board' });
+		const emitter = await this.buildBoardSocketEmitter({ socket, action: 'fetch-board' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
 			const board = await this.boardUc.findBoard(userId, data.boardId);
 
 			const responsePayload = BoardResponseMapper.mapToResponse(board);
+			await emitter.joinRoom(board);
 			await emitter.emitToClient(responsePayload);
 		} catch (err) {
 			emitter.emitFailure(data);
@@ -228,12 +230,12 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 	@SubscribeMessage('move-card-request')
 	@UseRequestContext()
 	async moveCard(socket: Socket, data: MoveCardMessageParams) {
-		const emitter = await this.buildBoardSocketEmitter({ socket, id: data.cardId, action: 'move-card' });
+		const emitter = await this.buildBoardSocketEmitter({ socket, action: 'move-card' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
-			await this.columnUc.moveCard(userId, data.cardId, data.toColumnId, data.newIndex);
+			const result = await this.columnUc.moveCard(userId, data.cardId, data.toColumnId, data.newIndex);
 
-			await emitter.emitToClientAndRoom(data);
+			await emitter.emitToClientAndRoom(data, result);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -243,12 +245,17 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 	@SubscribeMessage('move-column-request')
 	@UseRequestContext()
 	async moveColumn(socket: Socket, data: MoveColumnMessageParams) {
-		const emitter = await this.buildBoardSocketEmitter({ socket, id: data.targetBoardId, action: 'move-column' });
+		const emitter = await this.buildBoardSocketEmitter({ socket, action: 'move-column' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
-			await this.boardUc.moveColumn(userId, data.columnMove.columnId, data.targetBoardId, data.columnMove.addedIndex);
+			const result = await this.boardUc.moveColumn(
+				userId,
+				data.columnMove.columnId,
+				data.targetBoardId,
+				data.columnMove.addedIndex
+			);
 
-			await emitter.emitToClientAndRoom(data);
+			await emitter.emitToClientAndRoom(data, result);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -259,12 +266,12 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 	@TrackExecutionTime()
 	@UseRequestContext()
 	async updateColumnTitle(socket: Socket, data: UpdateColumnTitleMessageParams) {
-		const emitter = await this.buildBoardSocketEmitter({ socket, id: data.columnId, action: 'update-column-title' });
+		const emitter = await this.buildBoardSocketEmitter({ socket, action: 'update-column-title' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
-			await this.columnUc.updateColumnTitle(userId, data.columnId, data.newTitle);
+			const result = await this.columnUc.updateColumnTitle(userId, data.columnId, data.newTitle);
 
-			await emitter.emitToClientAndRoom(data);
+			await emitter.emitToClientAndRoom(data, result);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -274,12 +281,12 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 	@SubscribeMessage('update-board-visibility-request')
 	@UseRequestContext()
 	async updateBoardVisibility(socket: Socket, data: UpdateBoardVisibilityMessageParams) {
-		const emitter = await this.buildBoardSocketEmitter({ socket, id: data.boardId, action: 'update-board-visibility' });
+		const emitter = await this.buildBoardSocketEmitter({ socket, action: 'update-board-visibility' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
-			await this.boardUc.updateVisibility(userId, data.boardId, data.isVisible);
+			const result = await this.boardUc.updateVisibility(userId, data.boardId, data.isVisible);
 
-			await emitter.emitToClientAndRoom(data);
+			await emitter.emitToClientAndRoom(data, result);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -289,12 +296,12 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 	@SubscribeMessage('delete-column-request')
 	@UseRequestContext()
 	async deleteColumn(socket: Socket, data: DeleteColumnMessageParams) {
-		const emitter = await this.buildBoardSocketEmitter({ socket, id: data.columnId, action: 'delete-column' });
+		const emitter = await this.buildBoardSocketEmitter({ socket, action: 'delete-column' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
-			await this.columnUc.deleteColumn(userId, data.columnId);
+			const result = await this.columnUc.deleteColumn(userId, data.columnId);
 
-			await emitter.emitToClientAndRoom(data);
+			await emitter.emitToClientAndRoom(data, result);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -305,7 +312,7 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 	@TrackExecutionTime()
 	@UseRequestContext()
 	async fetchCards(socket: Socket, data: FetchCardsMessageParams) {
-		const emitter = await this.buildBoardSocketEmitter({ socket, id: data.cardIds[0], action: 'fetch-card' });
+		const emitter = await this.buildBoardSocketEmitter({ socket, action: 'fetch-card' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
 			const cards = await this.cardUc.findCards(userId, data.cardIds);
@@ -321,7 +328,7 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 	@SubscribeMessage('create-element-request')
 	@UseRequestContext()
 	async createElement(socket: Socket, data: CreateContentElementMessageParams) {
-		const emitter = await this.buildBoardSocketEmitter({ socket, id: data.cardId, action: 'create-element' });
+		const emitter = await this.buildBoardSocketEmitter({ socket, action: 'create-element' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
 			const element = await this.cardUc.createElement(userId, data.cardId, data.type, data.toPosition);
@@ -330,7 +337,7 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 				...data,
 				newElement: ContentElementResponseFactory.mapToResponse(element),
 			};
-			await emitter.emitToClientAndRoom(responsePayload);
+			await emitter.emitToClientAndRoom(responsePayload, element);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -341,12 +348,12 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 	@TrackExecutionTime()
 	@UseRequestContext()
 	async updateElement(socket: Socket, data: UpdateContentElementMessageParams) {
-		const emitter = await this.buildBoardSocketEmitter({ socket, id: data.elementId, action: 'update-element' });
+		const emitter = await this.buildBoardSocketEmitter({ socket, action: 'update-element' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
-			await this.elementUc.updateElement(userId, data.elementId, data.data.content);
+			const result = await this.elementUc.updateElement(userId, data.elementId, data.data.content);
 
-			await emitter.emitToClientAndRoom(data);
+			await emitter.emitToClientAndRoom(data, result);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -356,12 +363,12 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 	@SubscribeMessage('delete-element-request')
 	@UseRequestContext()
 	async deleteElement(socket: Socket, data: DeleteContentElementMessageParams) {
-		const emitter = await this.buildBoardSocketEmitter({ socket, id: data.elementId, action: 'delete-element' });
+		const emitter = await this.buildBoardSocketEmitter({ socket, action: 'delete-element' });
 		const { userId } = this.getCurrentUser(socket);
 
 		try {
-			await this.elementUc.deleteElement(userId, data.elementId);
-			await emitter.emitToClientAndRoom(data);
+			const result = await this.elementUc.deleteElement(userId, data.elementId);
+			await emitter.emitToClientAndRoom(data, result);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -371,28 +378,35 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 	@SubscribeMessage('move-element-request')
 	@UseRequestContext()
 	async moveElement(socket: Socket, data: MoveContentElementMessageParams) {
-		const emitter = await this.buildBoardSocketEmitter({ socket, id: data.elementId, action: 'move-element' });
+		const emitter = await this.buildBoardSocketEmitter({ socket, action: 'move-element' });
 		const { userId } = this.getCurrentUser(socket);
 
 		try {
-			await this.cardUc.moveElement(userId, data.elementId, data.toCardId, data.toPosition);
-			await emitter.emitToClientAndRoom(data);
+			const result = await this.cardUc.moveElement(userId, data.elementId, data.toCardId, data.toPosition);
+			await emitter.emitToClientAndRoom(data, result);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
 		await this.updateRoomsAndUsersMetrics(socket);
 	}
 
-	private async buildBoardSocketEmitter({ socket, id, action }: { socket: Socket; id: string; action: string }) {
-		const rootId = await this.getRootIdForId(id);
-		const room = `board_${rootId}`;
+	private async buildBoardSocketEmitter({ socket, action }: { socket: Socket; action: string }) {
+		const getRootId = (domainobject: AnyBoardNode) => {
+			return domainobject.rootId;
+		};
 		return {
-			async emitToClient(data: object) {
+			async joinRoom(boardNode: AnyBoardNode) {
+				const rootId = getRootId(boardNode);
+				const room = `board_${rootId}`;
 				await socket.join(room);
+			},
+			async emitToClient(data: object) {
 				socket.emit(`${action}-success`, { ...data, isOwnAction: true });
 			},
-			async emitToClientAndRoom(data: object) {
-				await socket.join(room);
+			async emitToClientAndRoom(data: object, boardNode: AnyBoardNode) {
+				const rootId = getRootId(boardNode);
+				const room = `board_${rootId}`;
+
 				socket.to(room).emit(`${action}-success`, { ...data, isOwnAction: false });
 				socket.emit(`${action}-success`, { ...data, isOwnAction: true });
 			},
@@ -400,12 +414,5 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 				socket.emit(`${action}-failure`, data);
 			},
 		};
-	}
-
-	private async getRootIdForId(id: string) {
-		const authorizable = await this.authorizableService.findById(id);
-		const rootId = authorizable.rootNode.id;
-
-		return rootId;
 	}
 }

--- a/apps/server/src/modules/board/gateway/board-collaboration.gateway.ts
+++ b/apps/server/src/modules/board/gateway/board-collaboration.gateway.ts
@@ -20,27 +20,25 @@ import {
 import { MetricsService } from '../metrics/metrics.service';
 import { TrackExecutionTime } from '../metrics/track-execution-time.decorator';
 import { BoardUc, CardUc, ColumnUc, ElementUc } from '../uc';
-import {
-	CreateCardMessageParams,
-	DeleteColumnMessageParams,
-	MoveCardMessageParams,
-	UpdateColumnTitleMessageParams,
-} from './dto';
-import BoardCollaborationConfiguration from './dto/board-collaboration-config';
+import { CreateCardMessageParams } from './dto/create-card.message.param';
 import { CreateColumnMessageParams } from './dto/create-column.message.param';
 import { CreateContentElementMessageParams } from './dto/create-content-element.message.param';
 import { DeleteBoardMessageParams } from './dto/delete-board.message.param';
 import { DeleteCardMessageParams } from './dto/delete-card.message.param';
 import { DeleteContentElementMessageParams } from './dto/delete-content-element.message.param';
+import { DeleteColumnMessageParams } from './dto/delete-column.message.param';
 import { FetchBoardMessageParams } from './dto/fetch-board.message.param';
 import { FetchCardsMessageParams } from './dto/fetch-cards.message.param';
+import { MoveCardMessageParams } from './dto/move-card.message.param';
 import { MoveColumnMessageParams } from './dto/move-column.message.param';
 import { MoveContentElementMessageParams } from './dto/move-content-element.message.param';
 import { UpdateBoardTitleMessageParams } from './dto/update-board-title.message.param';
 import { UpdateBoardVisibilityMessageParams } from './dto/update-board-visibility.message.param';
 import { UpdateCardHeightMessageParams } from './dto/update-card-height.message.param';
 import { UpdateCardTitleMessageParams } from './dto/update-card-title.message.param';
+import { UpdateColumnTitleMessageParams } from './dto/update-column-title.message.param';
 import { UpdateContentElementMessageParams } from './dto/update-content-element.message.param';
+import BoardCollaborationConfiguration from './dto/board-collaboration-config';
 import { AnyBoardNode } from '../domain';
 
 @UsePipes(new WsValidationPipe())

--- a/apps/server/src/modules/board/gateway/board-collaboration.gateway.ts
+++ b/apps/server/src/modules/board/gateway/board-collaboration.gateway.ts
@@ -90,9 +90,8 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 		const emitter = this.buildBoardSocketEmitter({ socket, action: 'delete-board' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
-			const result = await this.boardUc.deleteBoard(userId, data.boardId);
-
-			emitter.emitToClientAndRoom(data, result);
+			const board = await this.boardUc.deleteBoard(userId, data.boardId);
+			emitter.emitToClientAndRoom(data, board);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -106,9 +105,8 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 		const emitter = this.buildBoardSocketEmitter({ socket, action: 'update-board-title' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
-			const result = await this.boardUc.updateBoardTitle(userId, data.boardId, data.newTitle);
-
-			emitter.emitToClientAndRoom(data, result);
+			const board = await this.boardUc.updateBoardTitle(userId, data.boardId, data.newTitle);
+			emitter.emitToClientAndRoom(data, board);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -122,9 +120,8 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 		const emitter = this.buildBoardSocketEmitter({ socket, action: 'update-card-title' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
-			const result = await this.cardUc.updateCardTitle(userId, data.cardId, data.newTitle);
-
-			emitter.emitToClientAndRoom(data, result);
+			const card = await this.cardUc.updateCardTitle(userId, data.cardId, data.newTitle);
+			emitter.emitToClientAndRoom(data, card);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -137,9 +134,8 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 		const emitter = this.buildBoardSocketEmitter({ socket, action: 'update-card-height' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
-			const result = await this.cardUc.updateCardHeight(userId, data.cardId, data.newHeight);
-
-			emitter.emitToClientAndRoom(data, result);
+			const card = await this.cardUc.updateCardHeight(userId, data.cardId, data.newHeight);
+			emitter.emitToClientAndRoom(data, card);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -152,9 +148,8 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 		const emitter = this.buildBoardSocketEmitter({ socket, action: 'delete-card' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
-			const result = await this.cardUc.deleteCard(userId, data.cardId);
-
-			emitter.emitToClientAndRoom(data, result);
+			const card = await this.cardUc.deleteCard(userId, data.cardId);
+			emitter.emitToClientAndRoom(data, card);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -215,10 +210,9 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 		const { userId } = this.getCurrentUser(socket);
 		try {
 			const board = await this.boardUc.findBoard(userId, data.boardId);
-
 			const responsePayload = BoardResponseMapper.mapToResponse(board);
 			await emitter.joinRoom(board);
-			emitter.emitToClient(responsePayload);
+			emitter.emitSuccess(responsePayload);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -231,9 +225,8 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 		const emitter = this.buildBoardSocketEmitter({ socket, action: 'move-card' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
-			const result = await this.columnUc.moveCard(userId, data.cardId, data.toColumnId, data.newIndex);
-
-			emitter.emitToClientAndRoom(data, result);
+			const card = await this.columnUc.moveCard(userId, data.cardId, data.toColumnId, data.newIndex);
+			emitter.emitToClientAndRoom(data, card);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -246,14 +239,13 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 		const emitter = this.buildBoardSocketEmitter({ socket, action: 'move-column' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
-			const result = await this.boardUc.moveColumn(
+			const column = await this.boardUc.moveColumn(
 				userId,
 				data.columnMove.columnId,
 				data.targetBoardId,
 				data.columnMove.addedIndex
 			);
-
-			emitter.emitToClientAndRoom(data, result);
+			emitter.emitToClientAndRoom(data, column);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -267,9 +259,8 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 		const emitter = this.buildBoardSocketEmitter({ socket, action: 'update-column-title' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
-			const result = await this.columnUc.updateColumnTitle(userId, data.columnId, data.newTitle);
-
-			emitter.emitToClientAndRoom(data, result);
+			const column = await this.columnUc.updateColumnTitle(userId, data.columnId, data.newTitle);
+			emitter.emitToClientAndRoom(data, column);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -282,9 +273,8 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 		const emitter = this.buildBoardSocketEmitter({ socket, action: 'update-board-visibility' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
-			const result = await this.boardUc.updateVisibility(userId, data.boardId, data.isVisible);
-
-			emitter.emitToClientAndRoom(data, result);
+			const board = await this.boardUc.updateVisibility(userId, data.boardId, data.isVisible);
+			emitter.emitToClientAndRoom(data, board);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -297,9 +287,8 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 		const emitter = this.buildBoardSocketEmitter({ socket, action: 'delete-column' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
-			const result = await this.columnUc.deleteColumn(userId, data.columnId);
-
-			emitter.emitToClientAndRoom(data, result);
+			const column = await this.columnUc.deleteColumn(userId, data.columnId);
+			emitter.emitToClientAndRoom(data, column);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -316,7 +305,7 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 			const cards = await this.cardUc.findCards(userId, data.cardIds);
 			const cardResponses = cards.map((card) => CardResponseMapper.mapToResponse(card));
 
-			emitter.emitToClient({ cards: cardResponses, isOwnAction: false });
+			emitter.emitSuccess({ cards: cardResponses });
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -349,9 +338,8 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 		const emitter = this.buildBoardSocketEmitter({ socket, action: 'update-element' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
-			const result = await this.elementUc.updateElement(userId, data.elementId, data.data.content);
-
-			emitter.emitToClientAndRoom(data, result);
+			const element = await this.elementUc.updateElement(userId, data.elementId, data.data.content);
+			emitter.emitToClientAndRoom(data, element);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -365,8 +353,8 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 		const { userId } = this.getCurrentUser(socket);
 
 		try {
-			const result = await this.elementUc.deleteElement(userId, data.elementId);
-			emitter.emitToClientAndRoom(data, result);
+			const element = await this.elementUc.deleteElement(userId, data.elementId);
+			emitter.emitToClientAndRoom(data, element);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -380,8 +368,8 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 		const { userId } = this.getCurrentUser(socket);
 
 		try {
-			const result = await this.cardUc.moveElement(userId, data.elementId, data.toCardId, data.toPosition);
-			emitter.emitToClientAndRoom(data, result);
+			const element = await this.cardUc.moveElement(userId, data.elementId, data.toCardId, data.toPosition);
+			emitter.emitToClientAndRoom(data, element);
 		} catch (err) {
 			emitter.emitFailure(data);
 		}
@@ -396,7 +384,7 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 				const room = `board_${rootId}`;
 				await socket.join(room);
 			},
-			emitToClient(data: object) {
+			emitSuccess(data: object) {
 				socket.emit(`${action}-success`, { ...data, isOwnAction: true });
 			},
 			emitToClientAndRoom(data: object, boardNode: AnyBoardNode) {

--- a/apps/server/src/modules/board/gateway/board-collaboration.gateway.ts
+++ b/apps/server/src/modules/board/gateway/board-collaboration.gateway.ts
@@ -377,20 +377,17 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 	}
 
 	private buildBoardSocketEmitter({ socket, action }: { socket: Socket; action: string }) {
-		const getRootId = (domainobject: AnyBoardNode) => domainobject.rootId;
+		const getRoomName = (domainobject: AnyBoardNode) => `board_${domainobject.rootId}`;
 		return {
 			async joinRoom(boardNode: AnyBoardNode) {
-				const rootId = getRootId(boardNode);
-				const room = `board_${rootId}`;
+				const room = getRoomName(boardNode);
 				await socket.join(room);
 			},
 			emitSuccess(data: object) {
 				socket.emit(`${action}-success`, { ...data, isOwnAction: true });
 			},
 			emitToClientAndRoom(data: object, boardNode: AnyBoardNode) {
-				const rootId = getRootId(boardNode);
-				const room = `board_${rootId}`;
-
+				const room = getRoomName(boardNode);
 				socket.to(room).emit(`${action}-success`, { ...data, isOwnAction: false });
 				socket.emit(`${action}-success`, { ...data, isOwnAction: true });
 			},

--- a/apps/server/src/modules/board/gateway/dto/index.ts
+++ b/apps/server/src/modules/board/gateway/dto/index.ts
@@ -1,6 +1,39 @@
-import { MoveCardMessageParams } from './move-card.message.param';
 import { CreateCardMessageParams } from './create-card.message.param';
-import { UpdateColumnTitleMessageParams } from './update-column-title.message.param';
+import { CreateColumnMessageParams } from './create-column.message.param';
+import { CreateContentElementMessageParams } from './create-content-element.message.param';
+import { DeleteBoardMessageParams } from './delete-board.message.param';
+import { DeleteCardMessageParams } from './delete-card.message.param';
+import { DeleteContentElementMessageParams } from './delete-content-element.message.param';
 import { DeleteColumnMessageParams } from './delete-column.message.param';
+import { FetchBoardMessageParams } from './fetch-board.message.param';
+import { FetchCardsMessageParams } from './fetch-cards.message.param';
+import { MoveCardMessageParams } from './move-card.message.param';
+import { MoveColumnMessageParams } from './move-column.message.param';
+import { MoveContentElementMessageParams } from './move-content-element.message.param';
+import { UpdateBoardTitleMessageParams } from './update-board-title.message.param';
+import { UpdateBoardVisibilityMessageParams } from './update-board-visibility.message.param';
+import { UpdateCardHeightMessageParams } from './update-card-height.message.param';
+import { UpdateCardTitleMessageParams } from './update-card-title.message.param';
+import { UpdateColumnTitleMessageParams } from './update-column-title.message.param';
+import { UpdateContentElementMessageParams } from './update-content-element.message.param';
 
-export { MoveCardMessageParams, CreateCardMessageParams, UpdateColumnTitleMessageParams, DeleteColumnMessageParams };
+export {
+	CreateCardMessageParams,
+	CreateColumnMessageParams,
+	CreateContentElementMessageParams,
+	DeleteBoardMessageParams,
+	DeleteCardMessageParams,
+	DeleteColumnMessageParams,
+	DeleteContentElementMessageParams,
+	FetchBoardMessageParams,
+	FetchCardsMessageParams,
+	MoveCardMessageParams,
+	MoveColumnMessageParams,
+	MoveContentElementMessageParams,
+	UpdateBoardTitleMessageParams,
+	UpdateBoardVisibilityMessageParams,
+	UpdateCardHeightMessageParams,
+	UpdateCardTitleMessageParams,
+	UpdateColumnTitleMessageParams,
+	UpdateContentElementMessageParams,
+};

--- a/apps/server/src/modules/board/uc/board.uc.ts
+++ b/apps/server/src/modules/board/uc/board.uc.ts
@@ -65,22 +65,24 @@ export class BoardUc {
 		return board.context;
 	}
 
-	async deleteBoard(userId: EntityId, boardId: EntityId): Promise<void> {
+	async deleteBoard(userId: EntityId, boardId: EntityId): Promise<ColumnBoard> {
 		this.logger.debug({ action: 'deleteBoard', userId, boardId });
 
 		const board = await this.boardNodeService.findByClassAndId(ColumnBoard, boardId);
 		await this.boardPermissionService.checkPermission(userId, board, Action.write);
 
 		await this.boardNodeService.delete(board);
+		return board;
 	}
 
-	async updateBoardTitle(userId: EntityId, boardId: EntityId, title: string): Promise<void> {
+	async updateBoardTitle(userId: EntityId, boardId: EntityId, title: string): Promise<ColumnBoard> {
 		this.logger.debug({ action: 'updateBoardTitle', userId, boardId, title });
 
 		const board = await this.boardNodeService.findByClassAndId(ColumnBoard, boardId);
 		await this.boardPermissionService.checkPermission(userId, board, Action.write);
 
 		await this.boardNodeService.updateTitle(board, title);
+		return board;
 	}
 
 	async createColumn(userId: EntityId, boardId: EntityId): Promise<Column> {
@@ -101,7 +103,7 @@ export class BoardUc {
 		columnId: EntityId,
 		targetBoardId: EntityId,
 		targetPosition: number
-	): Promise<void> {
+	): Promise<Column> {
 		this.logger.debug({ action: 'moveColumn', userId, columnId, targetBoardId, targetPosition });
 
 		const column = await this.boardNodeService.findByClassAndId(Column, columnId);
@@ -111,6 +113,7 @@ export class BoardUc {
 		await this.boardPermissionService.checkPermission(userId, targetBoard, Action.write);
 
 		await this.boardNodeService.move(column, targetBoard, targetPosition);
+		return column;
 	}
 
 	async copyBoard(userId: EntityId, boardId: EntityId): Promise<CopyStatus> {
@@ -137,10 +140,11 @@ export class BoardUc {
 		return copyStatus;
 	}
 
-	async updateVisibility(userId: EntityId, boardId: EntityId, isVisible: boolean): Promise<void> {
+	async updateVisibility(userId: EntityId, boardId: EntityId, isVisible: boolean): Promise<ColumnBoard> {
 		const board = await this.boardNodeService.findByClassAndId(ColumnBoard, boardId);
 		await this.boardPermissionService.checkPermission(userId, board, Action.write);
 
 		await this.boardNodeService.updateVisibility(board, isVisible);
+		return board;
 	}
 }

--- a/apps/server/src/modules/board/uc/card.uc.spec.ts
+++ b/apps/server/src/modules/board/uc/card.uc.spec.ts
@@ -143,6 +143,7 @@ describe(CardUc.name, () => {
 		describe('when deleting a card', () => {
 			it('should call the service to find the card', async () => {
 				const { user, card } = setup();
+				boardNodeService.findByClassAndId.mockResolvedValueOnce(card);
 
 				await uc.deleteCard(user.id, card.id);
 

--- a/apps/server/src/modules/board/uc/card.uc.ts
+++ b/apps/server/src/modules/board/uc/card.uc.ts
@@ -46,31 +46,34 @@ export class CardUc {
 		return allowedCards;
 	}
 
-	async updateCardHeight(userId: EntityId, cardId: EntityId, height: number): Promise<void> {
+	async updateCardHeight(userId: EntityId, cardId: EntityId, height: number): Promise<Card> {
 		this.logger.debug({ action: 'updateCardHeight', userId, cardId, height });
 
 		const card = await this.boardNodeService.findByClassAndId(Card, cardId);
 		await this.boardNodePermissionService.checkPermission(userId, card, Action.write);
 
 		await this.boardNodeService.updateHeight(card, height);
+		return card;
 	}
 
-	async updateCardTitle(userId: EntityId, cardId: EntityId, title: string): Promise<void> {
+	async updateCardTitle(userId: EntityId, cardId: EntityId, title: string): Promise<Card> {
 		this.logger.debug({ action: 'updateCardTitle', userId, cardId, title });
 
 		const card = await this.boardNodeService.findByClassAndId(Card, cardId);
 		await this.boardNodePermissionService.checkPermission(userId, card, Action.write);
 
 		await this.boardNodeService.updateTitle(card, title);
+		return card;
 	}
 
-	async deleteCard(userId: EntityId, cardId: EntityId): Promise<void> {
+	async deleteCard(userId: EntityId, cardId: EntityId): Promise<Card> {
 		this.logger.debug({ action: 'deleteCard', userId, cardId });
 
 		const card = await this.boardNodeService.findByClassAndId(Card, cardId);
 		await this.boardNodePermissionService.checkPermission(userId, card, Action.write);
 
 		await this.boardNodeService.delete(card);
+		return card;
 	}
 
 	// --- elements ---
@@ -98,7 +101,7 @@ export class CardUc {
 		elementId: EntityId,
 		targetCardId: EntityId,
 		targetPosition: number
-	): Promise<void> {
+	): Promise<AnyContentElement> {
 		this.logger.debug({ action: 'moveElement', userId, elementId, targetCardId, targetPosition });
 
 		const element = await this.boardNodeService.findContentElementById(elementId);
@@ -108,5 +111,7 @@ export class CardUc {
 		await this.boardNodePermissionService.checkPermission(userId, targetCard, Action.write);
 
 		await this.boardNodeService.move(element, targetCard, targetPosition);
+
+		return element;
 	}
 }

--- a/apps/server/src/modules/board/uc/card.uc.ts
+++ b/apps/server/src/modules/board/uc/card.uc.ts
@@ -66,14 +66,15 @@ export class CardUc {
 		return card;
 	}
 
-	async deleteCard(userId: EntityId, cardId: EntityId): Promise<Card> {
+	async deleteCard(userId: EntityId, cardId: EntityId): Promise<EntityId> {
 		this.logger.debug({ action: 'deleteCard', userId, cardId });
 
 		const card = await this.boardNodeService.findByClassAndId(Card, cardId);
+		const { rootId } = card;
 		await this.boardNodePermissionService.checkPermission(userId, card, Action.write);
 
 		await this.boardNodeService.delete(card);
-		return card;
+		return rootId;
 	}
 
 	// --- elements ---

--- a/apps/server/src/modules/board/uc/column.uc.spec.ts
+++ b/apps/server/src/modules/board/uc/column.uc.spec.ts
@@ -73,6 +73,7 @@ describe(ColumnUc.name, () => {
 		describe('when deleting a column', () => {
 			it('should call the service to find the column', async () => {
 				const { user, column } = setup();
+				boardNodeService.findByClassAndId.mockResolvedValueOnce(column);
 
 				await uc.deleteColumn(user.id, column.id);
 

--- a/apps/server/src/modules/board/uc/column.uc.ts
+++ b/apps/server/src/modules/board/uc/column.uc.ts
@@ -17,22 +17,25 @@ export class ColumnUc {
 		this.logger.setContext(ColumnUc.name);
 	}
 
-	async deleteColumn(userId: EntityId, columnId: EntityId): Promise<void> {
+	async deleteColumn(userId: EntityId, columnId: EntityId): Promise<Column> {
 		this.logger.debug({ action: 'deleteColumn', userId, columnId });
 
 		const column = await this.boardNodeService.findByClassAndId(Column, columnId);
 		await this.boardNodePermissionService.checkPermission(userId, column, Action.write);
 
 		await this.boardNodeService.delete(column);
+
+		return column;
 	}
 
-	async updateColumnTitle(userId: EntityId, columnId: EntityId, title: string): Promise<void> {
+	async updateColumnTitle(userId: EntityId, columnId: EntityId, title: string): Promise<Column> {
 		this.logger.debug({ action: 'updateColumnTitle', userId, columnId, title });
 
 		const column = await this.boardNodeService.findByClassAndId(Column, columnId);
 		await this.boardNodePermissionService.checkPermission(userId, column, Action.write);
 
 		await this.boardNodeService.updateTitle(column, title);
+		return column;
 	}
 
 	async createCard(
@@ -53,7 +56,7 @@ export class ColumnUc {
 		return card;
 	}
 
-	async moveCard(userId: EntityId, cardId: EntityId, targetColumnId: EntityId, targetPosition: number): Promise<void> {
+	async moveCard(userId: EntityId, cardId: EntityId, targetColumnId: EntityId, targetPosition: number): Promise<Card> {
 		this.logger.debug({ action: 'moveCard', userId, cardId, targetColumnId, toPosition: targetPosition });
 
 		const card = await this.boardNodeService.findByClassAndId(Card, cardId);
@@ -63,5 +66,6 @@ export class ColumnUc {
 		await this.boardNodePermissionService.checkPermission(userId, targetColumn, Action.write);
 
 		await this.boardNodeService.move(card, targetColumn, targetPosition);
+		return card;
 	}
 }

--- a/apps/server/src/modules/board/uc/column.uc.ts
+++ b/apps/server/src/modules/board/uc/column.uc.ts
@@ -17,15 +17,16 @@ export class ColumnUc {
 		this.logger.setContext(ColumnUc.name);
 	}
 
-	async deleteColumn(userId: EntityId, columnId: EntityId): Promise<Column> {
+	async deleteColumn(userId: EntityId, columnId: EntityId): Promise<EntityId> {
 		this.logger.debug({ action: 'deleteColumn', userId, columnId });
 
 		const column = await this.boardNodeService.findByClassAndId(Column, columnId);
+		const { rootId } = column;
 		await this.boardNodePermissionService.checkPermission(userId, column, Action.write);
 
 		await this.boardNodeService.delete(column);
 
-		return column;
+		return rootId;
 	}
 
 	async updateColumnTitle(userId: EntityId, columnId: EntityId, title: string): Promise<Column> {

--- a/apps/server/src/modules/board/uc/element.uc.spec.ts
+++ b/apps/server/src/modules/board/uc/element.uc.spec.ts
@@ -135,6 +135,7 @@ describe(ElementUc.name, () => {
 
 			it('should call the service to find the element', async () => {
 				const { user, element } = setup();
+				boardNodeService.findContentElementById.mockResolvedValueOnce(element);
 
 				await uc.deleteElement(user.id, element.id);
 

--- a/apps/server/src/modules/board/uc/element.uc.ts
+++ b/apps/server/src/modules/board/uc/element.uc.ts
@@ -37,11 +37,12 @@ export class ElementUc {
 		return element;
 	}
 
-	async deleteElement(userId: EntityId, elementId: EntityId): Promise<void> {
+	async deleteElement(userId: EntityId, elementId: EntityId): Promise<AnyContentElement> {
 		const element = await this.boardNodeService.findContentElementById(elementId);
 		await this.boardPermissionService.checkPermission(userId, element, Action.write);
 
 		await this.boardNodeService.delete(element);
+		return element;
 	}
 
 	async checkElementReadPermission(userId: EntityId, elementId: EntityId): Promise<void> {

--- a/apps/server/src/modules/board/uc/element.uc.ts
+++ b/apps/server/src/modules/board/uc/element.uc.ts
@@ -37,12 +37,13 @@ export class ElementUc {
 		return element;
 	}
 
-	async deleteElement(userId: EntityId, elementId: EntityId): Promise<AnyContentElement> {
+	async deleteElement(userId: EntityId, elementId: EntityId): Promise<EntityId> {
 		const element = await this.boardNodeService.findContentElementById(elementId);
+		const { rootId } = element;
 		await this.boardPermissionService.checkPermission(userId, element, Action.write);
 
 		await this.boardNodeService.delete(element);
-		return element;
+		return rootId;
 	}
 
 	async checkElementReadPermission(userId: EntityId, elementId: EntityId): Promise<void> {

--- a/config/default.schema.json
+++ b/config/default.schema.json
@@ -1120,7 +1120,7 @@
 		},
 		"FEATURE_COLUMN_BOARD_COLLABORATIVE_TEXT_EDITOR_ENABLED": {
 			"type": "boolean",
-			"default": false,
+			"default": true,
 			"description": "Enable collaborative text editor in column board."
 		},
 		"FEATURE_COLUMN_BOARD_LINK_ELEMENT_ENABLED": {


### PR DESCRIPTION
# Description
Refactoring on the WebSocket-communication on the board:
Until now the BoardAuthorisableService was used to determine the root board of any action on the board.
Now, that the BoardDo contains its AncestorIds, this can be simplyfied by simply getting the rootId from the DO directly - reducing the amount of queries needed.

## Links to Tickets or other pull requests
BC-7236

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review

- [x] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
