### PR TITLE
BC-7583 - fix bugs in socket implementation

### DIFF
--- a/apps/server/src/modules/board/gateway/board-collaboration.gateway.ts
+++ b/apps/server/src/modules/board/gateway/board-collaboration.gateway.ts
@@ -169,7 +169,7 @@ export class BoardCollaborationGateway implements OnGatewayDisconnect {
 		const emitter = await this.buildBoardSocketEmitter({ socket, id: data.columnId, action: 'create-card' });
 		const { userId } = this.getCurrentUser(socket);
 		try {
-			const card = await this.columnUc.createCard(userId, data.columnId);
+			const card = await this.columnUc.createCard(userId, data.columnId, data.requiredEmptyElements);
 			const newCard = CardResponseMapper.mapToResponse(card);
 
 			const responsePayload = {

--- a/apps/server/src/modules/board/gateway/dto/create-card.message.param.ts
+++ b/apps/server/src/modules/board/gateway/dto/create-card.message.param.ts
@@ -1,6 +1,17 @@
-import { IsMongoId } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsMongoId, IsOptional } from 'class-validator';
+import { ContentElementType } from '../../domain';
 
 export class CreateCardMessageParams {
 	@IsMongoId()
 	columnId!: string;
+
+	@IsEnum(ContentElementType, { each: true })
+	@IsOptional()
+	@ApiPropertyOptional({
+		required: false,
+		isArray: true,
+		enum: ContentElementType,
+	})
+	requiredEmptyElements?: ContentElementType[];
 }


### PR DESCRIPTION
# Description
Fixing two bugs that were introduced with the implementation of websocket-communication for boards:

Problem 1:
When a new card gets created by clicking on the corresponding button, it gets created without an empty text field element.

Problem 2:
When the user hits enter key while being in a card title, a new text field element should be created at the beginning of the card and the cursor should jumo into it.

## Links to Tickets or other pull requests
[BC-7583](https://ticketsystem.dbildungscloud.de/browse/BC-7583)
https://github.com/hpi-schul-cloud/nuxt-client/pull/3306

## Approval for review

- [x] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
