### PR TITLE
BC-7592 - remove double FileStorageDeployment Ansible job

### DIFF
--- a/ansible/roles/schulcloud-server-core/tasks/main.yml
+++ b/ansible/roles/schulcloud-server-core/tasks/main.yml
@@ -113,12 +113,6 @@
       namespace: "{{ NAMESPACE }}"
       template: api-files-deployment.yml.j2
 
-  - name: FileStorageDeployment
-    kubernetes.core.k8s:
-      kubeconfig: ~/.kube/config
-      namespace: "{{ NAMESPACE }}"
-      template: api-files-deployment.yml.j2
-
   - name: File Storage Ingress
     kubernetes.core.k8s:
       kubeconfig: ~/.kube/config


### PR DESCRIPTION
# Description
Remove an double Ansible Job to apply the FileStorageDeployment 

## Links to Tickets or other pull requests
- https://ticketsystem.dbildungscloud.de/browse/BC-7592

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review

- [ ] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
