### PR TITLE
BC-7696 - fix configmaps for moin.schule CronJobs

### DIFF
--- a/ansible/roles/moin-schule-sync/templates/moin-schule-users-deletion-queueing-cronjob-configmap.yml.j2
+++ b/ansible/roles/moin-schule-sync/templates/moin-schule-users-deletion-queueing-cronjob-configmap.yml.j2
@@ -11,3 +11,4 @@ data:
   EXIT_ON_ERROR: "true"
   SC_DOMAIN: "{{ DOMAIN }}"
   FEATURE_PROMETHEUS_METRICS_ENABLED: "true"
+  ETHERPAD__PAD_URI: "https://{{ DOMAIN }}/etherpad/p"

--- a/ansible/roles/moin-schule-sync/templates/moin-schule-users-sync-cronjob-configmap.yml.j2
+++ b/ansible/roles/moin-schule-sync/templates/moin-schule-users-sync-cronjob-configmap.yml.j2
@@ -11,3 +11,4 @@ data:
   EXIT_ON_ERROR: "true"
   SC_DOMAIN: "{{ DOMAIN }}"
   FEATURE_PROMETHEUS_METRICS_ENABLED: "true"
+  ETHERPAD__PAD_URI: "https://{{ DOMAIN }}/etherpad/p"


### PR DESCRIPTION
# Description
Fix missing ETHERPAD__PAD_URI in the configmaps from the moin.schule cronjobs

## Links to Tickets or other pull requests
- https://ticketsystem.dbildungscloud.de/browse/BC-7696

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review

- [x] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
