### PR TITLE
BC-6938 - randomize cronjob execution point 

### DIFF
--- a/ansible/roles/h5p-library-management/templates/api-h5p-library-management-cronjob.yml.j2
+++ b/ansible/roles/h5p-library-management/templates/api-h5p-library-management-cronjob.yml.j2
@@ -70,7 +70,7 @@ spec:
           affinity:
             podAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
-              - weight: 100
+              - weight: 20
                 podAffinityTerm:
                   labelSelector:
                     matchExpressions:
@@ -78,6 +78,36 @@ spec:
                       operator: In
                       values:
                       - schulcloud-verbund
+                  topologyKey: "kubernetes.io/hostname"
+                  namespaceSelector: {}
+              - weight: 10
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: git.repo
+                      operator: In
+                      values:
+                      - {{ SCHULCLOUD_SERVER_REPO_NAME }}
+                  topologyKey: "kubernetes.io/hostname"
+                  namespaceSelector: {}
+              - weight: 10
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: git.branch
+                      operator: In
+                      values:
+                      - {{ SCHULCLOUD_SERVER_BRANCH_NAME }}
+                  topologyKey: "kubernetes.io/hostname"
+                  namespaceSelector: {}
+              - weight: 10
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: app.kubernetes.io/version
+                      operator: In
+                      values:
+                      - {{ SCHULCLOUD_SERVER_IMAGE_TAG }}
                   topologyKey: "kubernetes.io/hostname"
                   namespaceSelector: {}
 {% endif %}

--- a/ansible/roles/moin-schule-sync/templates/moin-schule-users-deletion-queueing-cronjob.yml.j2
+++ b/ansible/roles/moin-schule-sync/templates/moin-schule-users-deletion-queueing-cronjob.yml.j2
@@ -43,7 +43,7 @@ spec:
           affinity:
             podAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
-              - weight: 100
+              - weight: 20
                 podAffinityTerm:
                   labelSelector:
                     matchExpressions:
@@ -51,6 +51,36 @@ spec:
                       operator: In
                       values:
                       - schulcloud-verbund
+                  topologyKey: "kubernetes.io/hostname"
+                  namespaceSelector: {}
+              - weight: 10
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: git.repo
+                      operator: In
+                      values:
+                      - {{ SCHULCLOUD_SERVER_REPO_NAME }}
+                  topologyKey: "kubernetes.io/hostname"
+                  namespaceSelector: {}
+              - weight: 10
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: git.branch
+                      operator: In
+                      values:
+                      - {{ SCHULCLOUD_SERVER_BRANCH_NAME }}
+                  topologyKey: "kubernetes.io/hostname"
+                  namespaceSelector: {}
+              - weight: 10
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: app.kubernetes.io/version
+                      operator: In
+                      values:
+                      - {{ SCHULCLOUD_SERVER_IMAGE_TAG }}
                   topologyKey: "kubernetes.io/hostname"
                   namespaceSelector: {}
 {% endif %}

--- a/ansible/roles/moin-schule-sync/templates/moin-schule-users-sync-cronjob.yml.j2
+++ b/ansible/roles/moin-schule-sync/templates/moin-schule-users-sync-cronjob.yml.j2
@@ -43,7 +43,7 @@ spec:
           affinity:
             podAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
-              - weight: 100
+              - weight: 20
                 podAffinityTerm:
                   labelSelector:
                     matchExpressions:
@@ -51,6 +51,36 @@ spec:
                       operator: In
                       values:
                       - schulcloud-verbund
+                  topologyKey: "kubernetes.io/hostname"
+                  namespaceSelector: {}
+              - weight: 10
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: git.repo
+                      operator: In
+                      values:
+                      - {{ SCHULCLOUD_SERVER_REPO_NAME }}
+                  topologyKey: "kubernetes.io/hostname"
+                  namespaceSelector: {}
+              - weight: 10
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: git.branch
+                      operator: In
+                      values:
+                      - {{ SCHULCLOUD_SERVER_BRANCH_NAME }}
+                  topologyKey: "kubernetes.io/hostname"
+                  namespaceSelector: {}
+              - weight: 10
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: app.kubernetes.io/version
+                      operator: In
+                      values:
+                      - {{ SCHULCLOUD_SERVER_IMAGE_TAG }}
                   topologyKey: "kubernetes.io/hostname"
                   namespaceSelector: {}
 {% endif %}

--- a/ansible/roles/schulcloud-server-core/templates/api-delete-s3-files-cronjob.yml.j2
+++ b/ansible/roles/schulcloud-server-core/templates/api-delete-s3-files-cronjob.yml.j2
@@ -49,7 +49,7 @@ spec:
           affinity:
             podAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
-              - weight: 100
+              - weight: 20
                 podAffinityTerm:
                   labelSelector:
                     matchExpressions:
@@ -57,6 +57,36 @@ spec:
                       operator: In
                       values:
                       - schulcloud-verbund
+                  topologyKey: "kubernetes.io/hostname"
+                  namespaceSelector: {}
+              - weight: 10
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: git.repo
+                      operator: In
+                      values:
+                      - {{ SCHULCLOUD_SERVER_REPO_NAME }}
+                  topologyKey: "kubernetes.io/hostname"
+                  namespaceSelector: {}
+              - weight: 10
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: git.branch
+                      operator: In
+                      values:
+                      - {{ SCHULCLOUD_SERVER_BRANCH_NAME }}
+                  topologyKey: "kubernetes.io/hostname"
+                  namespaceSelector: {}
+              - weight: 10
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: app.kubernetes.io/version
+                      operator: In
+                      values:
+                      - {{ SCHULCLOUD_SERVER_IMAGE_TAG }}
                   topologyKey: "kubernetes.io/hostname"
                   namespaceSelector: {}
 {% endif %}

--- a/ansible/roles/schulcloud-server-core/templates/data-deletion-trigger-cronjob.yml.j2
+++ b/ansible/roles/schulcloud-server-core/templates/data-deletion-trigger-cronjob.yml.j2
@@ -58,7 +58,7 @@ spec:
           affinity:
             podAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
-              - weight: 100
+              - weight: 20
                 podAffinityTerm:
                   labelSelector:
                     matchExpressions:
@@ -66,6 +66,36 @@ spec:
                       operator: In
                       values:
                       - schulcloud-verbund
+                  topologyKey: "kubernetes.io/hostname"
+                  namespaceSelector: {}
+              - weight: 10
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: git.repo
+                      operator: In
+                      values:
+                      - {{ SCHULCLOUD_SERVER_REPO_NAME }}
+                  topologyKey: "kubernetes.io/hostname"
+                  namespaceSelector: {}
+              - weight: 10
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: git.branch
+                      operator: In
+                      values:
+                      - {{ SCHULCLOUD_SERVER_BRANCH_NAME }}
+                  topologyKey: "kubernetes.io/hostname"
+                  namespaceSelector: {}
+              - weight: 10
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: app.kubernetes.io/version
+                      operator: In
+                      values:
+                      - {{ SCHULCLOUD_SERVER_IMAGE_TAG }}
                   topologyKey: "kubernetes.io/hostname"
                   namespaceSelector: {}
 {% endif %}

--- a/ansible/roles/schulcloud-server-core/templates/tldraw-delete-files-cronjob.yml.j2
+++ b/ansible/roles/schulcloud-server-core/templates/tldraw-delete-files-cronjob.yml.j2
@@ -49,7 +49,7 @@ spec:
           affinity:
             podAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
-              - weight: 100
+              - weight: 20
                 podAffinityTerm:
                   labelSelector:
                     matchExpressions:
@@ -57,6 +57,36 @@ spec:
                       operator: In
                       values:
                       - schulcloud-verbund
+                  topologyKey: "kubernetes.io/hostname"
+                  namespaceSelector: {}
+              - weight: 10
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: git.repo
+                      operator: In
+                      values:
+                      - {{ SCHULCLOUD_SERVER_REPO_NAME }}
+                  topologyKey: "kubernetes.io/hostname"
+                  namespaceSelector: {}
+              - weight: 10
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: git.branch
+                      operator: In
+                      values:
+                      - {{ SCHULCLOUD_SERVER_BRANCH_NAME }}
+                  topologyKey: "kubernetes.io/hostname"
+                  namespaceSelector: {}
+              - weight: 10
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: app.kubernetes.io/version
+                      operator: In
+                      values:
+                      - {{ SCHULCLOUD_SERVER_IMAGE_TAG }}
                   topologyKey: "kubernetes.io/hostname"
                   namespaceSelector: {}
 {% endif %}

--- a/ansible/roles/schulcloud-server-ldapsync/templates/api-ldap-sync-full-cronjob.yml.j2
+++ b/ansible/roles/schulcloud-server-ldapsync/templates/api-ldap-sync-full-cronjob.yml.j2
@@ -43,7 +43,7 @@ spec:
           affinity:
             podAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
-              - weight: 100
+              - weight: 20
                 podAffinityTerm:
                   labelSelector:
                     matchExpressions:
@@ -51,6 +51,36 @@ spec:
                       operator: In
                       values:
                       - schulcloud-verbund
+                  topologyKey: "kubernetes.io/hostname"
+                  namespaceSelector: {}
+              - weight: 10
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: git.repo
+                      operator: In
+                      values:
+                      - {{ SCHULCLOUD_SERVER_REPO_NAME }}
+                  topologyKey: "kubernetes.io/hostname"
+                  namespaceSelector: {}
+              - weight: 10
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: git.branch
+                      operator: In
+                      values:
+                      - {{ SCHULCLOUD_SERVER_BRANCH_NAME }}
+                  topologyKey: "kubernetes.io/hostname"
+                  namespaceSelector: {}
+              - weight: 10
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: app.kubernetes.io/version
+                      operator: In
+                      values:
+                      - {{ SCHULCLOUD_SERVER_IMAGE_TAG }}
                   topologyKey: "kubernetes.io/hostname"
                   namespaceSelector: {}
 {% endif %}

--- a/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-base-cronjob.yml.j2
+++ b/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-base-cronjob.yml.j2
@@ -35,7 +35,7 @@ spec:
           affinity:
             podAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
-              - weight: 100
+              - weight: 20
                 podAffinityTerm:
                   labelSelector:
                     matchExpressions:

--- a/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-base-cronjob.yml.j2
+++ b/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-base-cronjob.yml.j2
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: ansible
     git.branch: {{ SCHULCLOUD_SERVER_BRANCH_NAME }}
     git.repo: {{ SCHULCLOUD_SERVER_REPO_NAME }}
-    infra.tools: true
+    infra.tools: "true"
   name: api-tsp-sync-base-cronjob
 spec:
   schedule: "{{ SERVER_TSP_SYNC_BASE_CRONJOB|default("9 3 * * *", true) }}"
@@ -52,7 +52,7 @@ spec:
                     - key: infra.tools
                       operator: In
                       values:
-                      - true
+                      - "true"
                   topologyKey: "kubernetes.io/hostname"
                   namespaceSelector: {}
 {% endif %}
@@ -66,4 +66,4 @@ spec:
             app.kubernetes.io/managed-by: ansible
             git.branch: {{ SCHULCLOUD_SERVER_BRANCH_NAME }}
             git.repo: {{ SCHULCLOUD_SERVER_REPO_NAME }}
-            infra.tools: true
+            infra.tools: "true"

--- a/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-base-cronjob.yml.j2
+++ b/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-base-cronjob.yml.j2
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: ansible
     git.branch: {{ SCHULCLOUD_SERVER_BRANCH_NAME }}
     git.repo: {{ SCHULCLOUD_SERVER_REPO_NAME }}
+    infra.tools: true
   name: api-tsp-sync-base-cronjob
 spec:
   schedule: "{{ SERVER_TSP_SYNC_BASE_CRONJOB|default("9 3 * * *", true) }}"
@@ -21,6 +22,7 @@ spec:
           containers:
           - name: api-tsp-sync-base-cronjob
             image: quay.io/schulcloudverbund/infra-tools:latest
+            imagePullPolicy: IfNotPresent
             envFrom:
             - secretRef:
                 name: api-secret
@@ -43,6 +45,16 @@ spec:
                       - schulcloud-verbund
                   topologyKey: "kubernetes.io/hostname"
                   namespaceSelector: {}
+              - weight: 10
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: infra.tools
+                      operator: In
+                      values:
+                      - true
+                  topologyKey: "kubernetes.io/hostname"
+                  namespaceSelector: {}
 {% endif %}
         metadata:
           labels:
@@ -54,3 +66,4 @@ spec:
             app.kubernetes.io/managed-by: ansible
             git.branch: {{ SCHULCLOUD_SERVER_BRANCH_NAME }}
             git.repo: {{ SCHULCLOUD_SERVER_REPO_NAME }}
+            infra.tools: true

--- a/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-school-cronjob.yml.j2
+++ b/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-school-cronjob.yml.j2
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: ansible
     git.branch: {{ SCHULCLOUD_SERVER_BRANCH_NAME }}
     git.repo: {{ SCHULCLOUD_SERVER_REPO_NAME }}
+    infra.tools: true
   name: api-tsp-sync-school-cronjob
 spec:
   schedule: "{{ SERVER_TSP_SYNC_SCHOOL_CRONJOB|default("39 3 * * *", true) }}"
@@ -21,6 +22,7 @@ spec:
           containers:
           - name: api-tsp-sync-school-cronjob
             image: quay.io/schulcloudverbund/infra-tools:latest
+            imagePullPolicy: IfNotPresent
             envFrom:
             - secretRef:
                 name: api-secret
@@ -33,7 +35,7 @@ spec:
           affinity:
             podAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
-              - weight: 100
+              - weight: 20
                 podAffinityTerm:
                   labelSelector:
                     matchExpressions:
@@ -41,6 +43,16 @@ spec:
                       operator: In
                       values:
                       - schulcloud-verbund
+                  topologyKey: "kubernetes.io/hostname"
+                  namespaceSelector: {}
+              - weight: 10
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: infra.tools
+                      operator: In
+                      values:
+                      - true
                   topologyKey: "kubernetes.io/hostname"
                   namespaceSelector: {}
 {% endif %}
@@ -54,3 +66,4 @@ spec:
             app.kubernetes.io/managed-by: ansible
             git.branch: {{ SCHULCLOUD_SERVER_BRANCH_NAME }}
             git.repo: {{ SCHULCLOUD_SERVER_REPO_NAME }}
+            infra.tools: true

--- a/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-school-cronjob.yml.j2
+++ b/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-school-cronjob.yml.j2
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: ansible
     git.branch: {{ SCHULCLOUD_SERVER_BRANCH_NAME }}
     git.repo: {{ SCHULCLOUD_SERVER_REPO_NAME }}
-    infra.tools: true
+    infra.tools: "true"
   name: api-tsp-sync-school-cronjob
 spec:
   schedule: "{{ SERVER_TSP_SYNC_SCHOOL_CRONJOB|default("39 3 * * *", true) }}"
@@ -52,7 +52,7 @@ spec:
                     - key: infra.tools
                       operator: In
                       values:
-                      - true
+                      - "true"
                   topologyKey: "kubernetes.io/hostname"
                   namespaceSelector: {}
 {% endif %}
@@ -66,4 +66,4 @@ spec:
             app.kubernetes.io/managed-by: ansible
             git.branch: {{ SCHULCLOUD_SERVER_BRANCH_NAME }}
             git.repo: {{ SCHULCLOUD_SERVER_REPO_NAME }}
-            infra.tools: true
+            infra.tools: "true"


### PR DESCRIPTION
# Description
This work should randomize the timepoint for cronjobs to run. 
That should be help to decrease the amount of cron jobs who run at the same time and this should decrease the scale-up and scale-down rate for the kubernetes worker at least.

## Links to Tickets or other pull requests

- https://ticketsystem.dbildungscloud.de/browse/BC-6938
- https://github.com/hpi-schul-cloud/dof_app_deploy/pull/921

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review

- [ ] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
