### PR TITLE
EW-994 provided a new API to get course metadata by ID

### DIFF
--- a/apps/server/src/modules/learnroom/controller/api-test/course.api.spec.ts
+++ b/apps/server/src/modules/learnroom/controller/api-test/course.api.spec.ts
@@ -15,7 +15,6 @@ import {
 import { readFile } from 'node:fs/promises';
 import { CourseMetadataListResponse } from '../dto';
 import { CourseCommonCartridgeMetadataResponse } from '../dto/course-cc-metadata.response';
-import exp from 'node:constants';
 
 const createStudent = () => {
 	const { studentUser, studentAccount } = UserAndAccountTestFactory.buildStudent({}, [Permission.COURSE_VIEW]);

--- a/apps/server/src/modules/learnroom/controller/api-test/course.api.spec.ts
+++ b/apps/server/src/modules/learnroom/controller/api-test/course.api.spec.ts
@@ -246,20 +246,21 @@ describe('Course Controller (API)', () => {
 	});
 
 	describe('[GET] /courses/:courseId', () => {
-		const setup = () => {
+		const setup = async () => {
 			const teacher = createTeacher();
 			const course = courseFactory.buildWithId({
 				teachers: [teacher.user],
 				students: [],
 			});
 
+			await em.persistAndFlush([teacher.account, teacher.user, course]);
+			em.clear();
+
 			return { course, teacher };
 		};
 
 		it('should return common cartridge metadata of a course', async () => {
-			const { course, teacher } = setup();
-			await em.persistAndFlush([teacher.account, teacher.user, course]);
-			em.clear();
+			const { course, teacher } = await setup();
 
 			const loggedInClient = await testApiClient.login(teacher.account);
 			const response = await loggedInClient.get(`${course.id}`);

--- a/apps/server/src/modules/learnroom/controller/course.controller.ts
+++ b/apps/server/src/modules/learnroom/controller/course.controller.ts
@@ -137,6 +137,7 @@ export class CourseController {
 	@ApiInternalServerErrorResponse({ description: 'Internal server error.' })
 	public async getCourseById(@Param() param: CourseUrlParams): Promise<Course> {
 		const course: Course = await this.courseUc.findCourseById(param.courseId);
+
 		return course;
 	}
 }

--- a/apps/server/src/modules/learnroom/controller/course.controller.ts
+++ b/apps/server/src/modules/learnroom/controller/course.controller.ts
@@ -27,7 +27,6 @@ import {
 } from '@nestjs/swagger';
 import { PaginationParams } from '@shared/controller/';
 import { Response } from 'express';
-import { Course } from '@shared/domain/entity';
 import { CourseMapper } from '../mapper/course.mapper';
 import { CourseExportUc, CourseImportUc, CourseSyncUc, CourseUc } from '../uc';
 import { CommonCartridgeFileValidatorPipe } from '../utils';
@@ -137,7 +136,7 @@ export class CourseController {
 	@ApiBadRequestResponse({ description: 'Request data has invalid format.' })
 	@ApiInternalServerErrorResponse({ description: 'Internal server error.' })
 	public async getCourseById(@Param() param: CourseUrlParams): Promise<CourseCommonCartridgeMetadataResponse> {
-		const course: Course = await this.courseUc.findCourseById(param.courseId);
+		const course = await this.courseUc.findCourseById(param.courseId);
 
 		return CourseMapper.mapToCommonCartridgeMetadataResponse(course);
 	}

--- a/apps/server/src/modules/learnroom/controller/course.controller.ts
+++ b/apps/server/src/modules/learnroom/controller/course.controller.ts
@@ -27,6 +27,7 @@ import {
 } from '@nestjs/swagger';
 import { PaginationParams } from '@shared/controller/';
 import { Response } from 'express';
+import { Course } from '@shared/domain/entity';
 import { CourseMapper } from '../mapper/course.mapper';
 import { CourseExportUc, CourseImportUc, CourseSyncUc, CourseUc } from '../uc';
 import { CommonCartridgeFileValidatorPipe } from '../utils';
@@ -128,5 +129,14 @@ export class CourseController {
 		return {
 			[currentUser.userId]: permissions,
 		};
+	}
+
+	@Get(':courseId')
+	@ApiOperation({ summary: 'Get a course by Id.' })
+	@ApiBadRequestResponse({ description: 'Request data has invalid format.' })
+	@ApiInternalServerErrorResponse({ description: 'Internal server error.' })
+	public async getCourseById(@Param() param: CourseUrlParams): Promise<Course> {
+		const course: Course = await this.courseUc.findCourseById(param.courseId);
+		return course;
 	}
 }

--- a/apps/server/src/modules/learnroom/controller/course.controller.ts
+++ b/apps/server/src/modules/learnroom/controller/course.controller.ts
@@ -33,6 +33,7 @@ import { CourseExportUc, CourseImportUc, CourseSyncUc, CourseUc } from '../uc';
 import { CommonCartridgeFileValidatorPipe } from '../utils';
 import { CourseImportBodyParams, CourseMetadataListResponse, CourseQueryParams, CourseUrlParams } from './dto';
 import { CourseExportBodyParams } from './dto/course-export.body.params';
+import { CourseCommonCartridgeMetadataResponse } from './dto/course-cc-metadata.response';
 
 @ApiTags('Courses')
 @Authenticate('jwt')
@@ -135,9 +136,9 @@ export class CourseController {
 	@ApiOperation({ summary: 'Get a course by Id.' })
 	@ApiBadRequestResponse({ description: 'Request data has invalid format.' })
 	@ApiInternalServerErrorResponse({ description: 'Internal server error.' })
-	public async getCourseById(@Param() param: CourseUrlParams): Promise<Course> {
+	public async getCourseById(@Param() param: CourseUrlParams): Promise<CourseCommonCartridgeMetadataResponse> {
 		const course: Course = await this.courseUc.findCourseById(param.courseId);
 
-		return course;
+		return CourseMapper.mapToCommonCartridgeMetadataResponse(course);
 	}
 }

--- a/apps/server/src/modules/learnroom/controller/course.controller.ts
+++ b/apps/server/src/modules/learnroom/controller/course.controller.ts
@@ -133,7 +133,7 @@ export class CourseController {
 	}
 
 	@Get(':courseId')
-	@ApiOperation({ summary: 'Get a course by Id.' })
+	@ApiOperation({ summary: 'Get common cartridge metadata of a course by Id.' })
 	@ApiBadRequestResponse({ description: 'Request data has invalid format.' })
 	@ApiInternalServerErrorResponse({ description: 'Internal server error.' })
 	public async getCourseById(@Param() param: CourseUrlParams): Promise<CourseCommonCartridgeMetadataResponse> {

--- a/apps/server/src/modules/learnroom/controller/dto/course-cc-metadata.response.ts
+++ b/apps/server/src/modules/learnroom/controller/dto/course-cc-metadata.response.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { EntityId } from '@shared/domain/types';
+
+export class CourseCommonCartridgeMetadataResponse {
+	constructor(id: EntityId, title: string, copyrightOwners: string[], creationDate?: Date) {
+		this.id = id;
+		this.title = title;
+		this.creationDate = creationDate;
+		this.copyRightOwners = copyrightOwners;
+	}
+
+	@ApiProperty({
+		description: 'The id of the Grid element',
+		pattern: '[a-f0-9]{24}',
+	})
+	id: string;
+
+	@ApiProperty({
+		description: 'Title of the Grid element',
+	})
+	title: string;
+
+	@ApiProperty({
+		description: 'Creation date of the course',
+	})
+	creationDate?: Date;
+
+	@ApiProperty({
+		description: 'Copy right owners of the course',
+	})
+	copyRightOwners: string[];
+}

--- a/apps/server/src/modules/learnroom/controller/dto/course-cc-metadata.response.ts
+++ b/apps/server/src/modules/learnroom/controller/dto/course-cc-metadata.response.ts
@@ -10,13 +10,13 @@ export class CourseCommonCartridgeMetadataResponse {
 	}
 
 	@ApiProperty({
-		description: 'The id of the Grid element',
+		description: 'The id of the course',
 		pattern: '[a-f0-9]{24}',
 	})
 	id: string;
 
 	@ApiProperty({
-		description: 'Title of the Grid element',
+		description: 'Title of the course',
 	})
 	title: string;
 

--- a/apps/server/src/modules/learnroom/mapper/course.mapper.ts
+++ b/apps/server/src/modules/learnroom/mapper/course.mapper.ts
@@ -26,6 +26,7 @@ export class CourseMapper {
 			teachers,
 			courseMetadata.startDate
 		);
+
 		return courseCCMetadataResopne;
 	}
 }

--- a/apps/server/src/modules/learnroom/mapper/course.mapper.ts
+++ b/apps/server/src/modules/learnroom/mapper/course.mapper.ts
@@ -1,5 +1,6 @@
 import { Course } from '@shared/domain/entity';
 import { CourseMetadataResponse } from '../controller/dto';
+import { CourseCommonCartridgeMetadataResponse } from '../controller/dto/course-cc-metadata.response';
 
 export class CourseMapper {
 	static mapToMetadataResponse(course: Course): CourseMetadataResponse {
@@ -14,5 +15,17 @@ export class CourseMapper {
 			courseMetadata.copyingSince
 		);
 		return dto;
+	}
+
+	static mapToCommonCartridgeMetadataResponse(course: Course): CourseCommonCartridgeMetadataResponse {
+		const courseMetadata = course.getMetadata();
+		const teachers = course.teachers.toArray().map((teacher) => `${teacher.firstName} ${teacher.lastName}`);
+		const courseCCMetadataResopne: CourseCommonCartridgeMetadataResponse = new CourseCommonCartridgeMetadataResponse(
+			courseMetadata.id,
+			courseMetadata.title,
+			teachers,
+			courseMetadata.startDate
+		);
+		return courseCCMetadataResopne;
 	}
 }

--- a/apps/server/src/modules/learnroom/uc/course.uc.spec.ts
+++ b/apps/server/src/modules/learnroom/uc/course.uc.spec.ts
@@ -103,4 +103,19 @@ describe('CourseUc', () => {
 			expect(roleService.findByName).toHaveBeenCalledWith(RoleName.TEACHER);
 		});
 	});
+
+	describe('findCourseById', () => {
+		const setup = () => {
+			const course = courseFactory.buildWithId();
+			return { course };
+		};
+		it('should return course by id', async () => {
+			const { course } = setup();
+			courseService.findById.mockResolvedValue(course);
+			const result = await uc.findCourseById(course.id);
+
+			expect(result).toEqual(course);
+			expect(courseService.findById).toHaveBeenCalledWith(course.id);
+		});
+	});
 });

--- a/apps/server/src/modules/learnroom/uc/course.uc.spec.ts
+++ b/apps/server/src/modules/learnroom/uc/course.uc.spec.ts
@@ -107,11 +107,12 @@ describe('CourseUc', () => {
 	describe('findCourseById', () => {
 		const setup = () => {
 			const course = courseFactory.buildWithId();
+			courseService.findById.mockResolvedValue(course);
 			return { course };
 		};
+
 		it('should return course by id', async () => {
 			const { course } = setup();
-			courseService.findById.mockResolvedValue(course);
 			const result = await uc.findCourseById(course.id);
 
 			expect(result).toEqual(course);

--- a/apps/server/src/modules/learnroom/uc/course.uc.ts
+++ b/apps/server/src/modules/learnroom/uc/course.uc.ts
@@ -30,4 +30,8 @@ export class CourseUc {
 
 		return role.permissions ?? [];
 	}
+
+	public async findCourseById(courseId: EntityId): Promise<Course> {
+		return this.courseService.findById(courseId);
+	}
 }


### PR DESCRIPTION
# Description
In this ticket a new Get-API is provided to get specific metadata of a course that is needed for the Common Cartridge Export Microservice

## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/EW-994

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review

- [ ] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
