### PR TITLE
EW-1000 renamed the get course by id API

### DIFF
--- a/apps/server/src/modules/learnroom/controller/api-test/course.api.spec.ts
+++ b/apps/server/src/modules/learnroom/controller/api-test/course.api.spec.ts
@@ -263,7 +263,7 @@ describe('Course Controller (API)', () => {
 			const { course, teacher } = await setup();
 
 			const loggedInClient = await testApiClient.login(teacher.account);
-			const response = await loggedInClient.get(`${course.id}`);
+			const response = await loggedInClient.get(`${course.id}/cc-metadata`);
 			const data = response.body as CourseCommonCartridgeMetadataResponse;
 
 			expect(response.statusCode).toBe(200);

--- a/apps/server/src/modules/learnroom/controller/api-test/course.api.spec.ts
+++ b/apps/server/src/modules/learnroom/controller/api-test/course.api.spec.ts
@@ -245,7 +245,7 @@ describe('Course Controller (API)', () => {
 		});
 	});
 
-	describe('[GET] /courses/:courseId', () => {
+	describe('[GET] /courses/:courseId/cc-metadata', () => {
 		const setup = async () => {
 			const teacher = createTeacher();
 			const course = courseFactory.buildWithId({

--- a/apps/server/src/modules/learnroom/controller/course.controller.ts
+++ b/apps/server/src/modules/learnroom/controller/course.controller.ts
@@ -135,7 +135,9 @@ export class CourseController {
 	@ApiOperation({ summary: 'Get common cartridge metadata of a course by Id.' })
 	@ApiBadRequestResponse({ description: 'Request data has invalid format.' })
 	@ApiInternalServerErrorResponse({ description: 'Internal server error.' })
-	public async getCourseById(@Param() param: CourseUrlParams): Promise<CourseCommonCartridgeMetadataResponse> {
+	public async getCourseCcMetadataById(
+		@Param() param: CourseUrlParams
+	): Promise<CourseCommonCartridgeMetadataResponse> {
 		const course = await this.courseUc.findCourseById(param.courseId);
 
 		return CourseMapper.mapToCommonCartridgeMetadataResponse(course);

--- a/apps/server/src/modules/learnroom/controller/course.controller.ts
+++ b/apps/server/src/modules/learnroom/controller/course.controller.ts
@@ -131,7 +131,7 @@ export class CourseController {
 		};
 	}
 
-	@Get(':courseId')
+	@Get(':courseId/cc-metadata')
 	@ApiOperation({ summary: 'Get common cartridge metadata of a course by Id.' })
 	@ApiBadRequestResponse({ description: 'Request data has invalid format.' })
 	@ApiInternalServerErrorResponse({ description: 'Internal server error.' })


### PR DESCRIPTION
# Description
In this ticket the path of the API get common cartridge metadata of a course by id was changed from /courses/:courseId to /courses/:courseId/cc-metadata

## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/EW-1000

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review

- [ ] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
