### PR TITLE
BC-8267 - aktivate for dev thr only the one mongo cluster for all mode

### DIFF
--- a/ansible/roles/common-cartridge/templates/external-secret.yml.j2
+++ b/ansible/roles/common-cartridge/templates/external-secret.yml.j2
@@ -16,7 +16,7 @@ spec:
       engineVersion: v2
       mergePolicy: Merge
       data:
-        DB_URL: "{{ '{{ .MONGO_MANAGEMENT_TEMPLATE_URL }}/' ~ MONGO_MANAGEMENT_PREFIX ~ 'scapp' }}"
+        DB_URL: "{{ '{{ .MONGO_MANAGEMENT_TEMPLATE_URL }}/' ~ MONGO_MANAGEMENT_PREFIX ~ 'scapp' ~ MONGO_MANAGEMENT_POSTFIX }}"
   dataFrom:
   - extract:
       key: common-cartridge-secret{{ EXTERNAL_SECRETS_POSTFIX }}

--- a/ansible/roles/moin-schule-sync/templates/moin-schule-sync-external-secret.yml.j2
+++ b/ansible/roles/moin-schule-sync/templates/moin-schule-sync-external-secret.yml.j2
@@ -16,7 +16,7 @@ spec:
       engineVersion: v2
       mergePolicy: Merge
       data:
-        DB_URL: "{{ '{{ .MONGO_MANAGEMENT_TEMPLATE_URL }}/' ~ MONGO_MANAGEMENT_PREFIX ~ 'scapp' }}"
+        DB_URL: "{{ '{{ .MONGO_MANAGEMENT_TEMPLATE_URL }}/' ~ MONGO_MANAGEMENT_PREFIX ~ 'scapp' ~ MONGO_MANAGEMENT_POSTFIX }}"
   dataFrom:
   - extract:
       key: moin-schule-sync-secret{{ EXTERNAL_SECRETS_POSTFIX }}

--- a/ansible/roles/schulcloud-server-core/templates/admin-api-server-external-secret.yml.j2
+++ b/ansible/roles/schulcloud-server-core/templates/admin-api-server-external-secret.yml.j2
@@ -16,7 +16,7 @@ spec:
       engineVersion: v2
       mergePolicy: Merge
       data:
-        DB_URL: "{{ '{{ .MONGO_MANAGEMENT_TEMPLATE_URL }}/' ~ MONGO_MANAGEMENT_PREFIX ~ 'scapp' }}"
+        DB_URL: "{{ '{{ .MONGO_MANAGEMENT_TEMPLATE_URL }}/' ~ MONGO_MANAGEMENT_PREFIX ~ 'scapp' ~ MONGO_MANAGEMENT_POSTFIX }}"
   dataFrom:
   - extract:
       key: admin-api-server-secret{{ EXTERNAL_SECRETS_POSTFIX }}

--- a/ansible/roles/schulcloud-server-core/templates/amqp-files-external-secret.yml.j2
+++ b/ansible/roles/schulcloud-server-core/templates/amqp-files-external-secret.yml.j2
@@ -16,7 +16,7 @@ spec:
       engineVersion: v2
       mergePolicy: Merge
       data:
-        DB_URL: "{{ '{{ .MONGO_MANAGEMENT_TEMPLATE_URL }}/' ~ MONGO_MANAGEMENT_PREFIX ~ 'scapp' }}"
+        DB_URL: "{{ '{{ .MONGO_MANAGEMENT_TEMPLATE_URL }}/' ~ MONGO_MANAGEMENT_PREFIX ~ 'scapp' ~ MONGO_MANAGEMENT_POSTFIX }}"
   dataFrom:
   - extract:
       key: amqp-files-secret{{ EXTERNAL_SECRETS_POSTFIX }}

--- a/ansible/roles/schulcloud-server-core/templates/external-secret-admin-api-client.yml.j2
+++ b/ansible/roles/schulcloud-server-core/templates/external-secret-admin-api-client.yml.j2
@@ -16,7 +16,7 @@ spec:
       engineVersion: v2
       mergePolicy: Merge
       data:
-        DB_URL: "{{ '{{ .MONGO_MANAGEMENT_TEMPLATE_URL }}/' ~ MONGO_MANAGEMENT_PREFIX ~ 'scapp' }}"
+        DB_URL: "{{ '{{ .MONGO_MANAGEMENT_TEMPLATE_URL }}/' ~ MONGO_MANAGEMENT_PREFIX ~ 'scapp' ~ MONGO_MANAGEMENT_POSTFIX }}"
   dataFrom:
   - extract:
       key: admin-api-client-secret{{ EXTERNAL_SECRETS_POSTFIX }}

--- a/ansible/roles/schulcloud-server-core/templates/external-secret.yml.j2
+++ b/ansible/roles/schulcloud-server-core/templates/external-secret.yml.j2
@@ -16,9 +16,9 @@ spec:
       engineVersion: v2
       mergePolicy: Merge
       data:
-        DB_URL: "{{ '{{ .MONGO_MANAGEMENT_TEMPLATE_URL }}/' ~ MONGO_MANAGEMENT_PREFIX ~ 'scapp' }}"
-        DATABASE__URL: "{{ '{{ .MONGO_MANAGEMENT_TEMPLATE_URL }}/' ~ MONGO_MANAGEMENT_PREFIX ~ 'scapp' }}"
-        TLDRAW_DB_URL: "{{ '{{ .MONGO_MANAGEMENT_TEMPLATE_URL }}/' ~ MONGO_MANAGEMENT_PREFIX ~ 'tldraw' }}"
+        DB_URL: "{{ '{{ .MONGO_MANAGEMENT_TEMPLATE_URL }}/' ~ MONGO_MANAGEMENT_PREFIX ~ 'scapp' ~ MONGO_MANAGEMENT_POSTFIX }}"
+        DATABASE__URL: "{{ '{{ .MONGO_MANAGEMENT_TEMPLATE_URL }}/' ~ MONGO_MANAGEMENT_PREFIX ~ 'scapp' ~ MONGO_MANAGEMENT_POSTFIX }}"
+        TLDRAW_DB_URL: "{{ '{{ .MONGO_MANAGEMENT_TEMPLATE_URL }}/' ~ MONGO_MANAGEMENT_PREFIX ~ 'tldraw' ~ MONGO_MANAGEMENT_POSTFIX }}"
   dataFrom:
   - extract:
       key: api-secret{{ EXTERNAL_SECRETS_POSTFIX }}

--- a/ansible/roles/schulcloud-server-core/templates/tldraw-server-external-secret.yml.j2
+++ b/ansible/roles/schulcloud-server-core/templates/tldraw-server-external-secret.yml.j2
@@ -16,7 +16,7 @@ spec:
       engineVersion: v2
       mergePolicy: Merge
       data:
-        TLDRAW_DB_URL: "{{ '{{ .MONGO_MANAGEMENT_TEMPLATE_URL }}/' ~ MONGO_MANAGEMENT_PREFIX ~ 'tldraw' }}"
+        TLDRAW_DB_URL: "{{ '{{ .MONGO_MANAGEMENT_TEMPLATE_URL }}/' ~ MONGO_MANAGEMENT_PREFIX ~ 'tldraw' ~ MONGO_MANAGEMENT_POSTFIX }}"
   dataFrom:
   - extract:
       key: tldraw-server-secret{{ EXTERNAL_SECRETS_POSTFIX }}


### PR DESCRIPTION
# Description
To reduce the trouble by the lag of the nfs PVCs and mongo DB on dev thr we activate for dev THR the mode to use one mongodb replicaset for all.

## Links to Tickets or other pull requests
- https://ticketsystem.dbildungscloud.de/browse/BC-8267
- hpi-schul-cloud/tldraw-server#24
- hpi-schul-cloud/dof_app_deploy#998

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to be discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Approval for review

- [x] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
