### PR TITLE
BC-8362 - RoomMember groups are shown in class administration

### DIFF
--- a/apps/server/src/modules/group/uc/class-group.uc.spec.ts
+++ b/apps/server/src/modules/group/uc/class-group.uc.spec.ts
@@ -33,7 +33,7 @@ import {
 	userFactory,
 } from '@shared/testing';
 import { ClassRequestContext, SchoolYearQueryType } from '../controller/dto/interface';
-import { Group, GroupFilter } from '../domain';
+import { Group, GroupFilter, GroupTypes } from '../domain';
 import { UnknownQueryTypeLoggableException } from '../loggable';
 import { GroupService } from '../service';
 import { ClassInfoDto } from './dto';
@@ -407,12 +407,15 @@ describe('ClassGroupUc', () => {
 					});
 				});
 
-				it('should call group service with userId and no pagination', async () => {
+				it('should call group service with userId, group type class and no pagination', async () => {
 					const { teacherUser } = setup();
 
 					await uc.findAllClasses(teacherUser.id, teacherUser.school.id);
 
-					expect(groupService.findGroups).toHaveBeenCalledWith<[GroupFilter]>({ userId: teacherUser.id });
+					expect(groupService.findGroups).toHaveBeenCalledWith<[GroupFilter]>({
+						userId: teacherUser.id,
+						groupTypes: [GroupTypes.CLASS],
+					});
 				});
 			});
 
@@ -767,12 +770,15 @@ describe('ClassGroupUc', () => {
 					});
 				});
 
-				it('should call group service with schoolId and no pagination', async () => {
+				it('should call group service with schoolId, group type class and no pagination', async () => {
 					const { teacherUser } = setup();
 
 					await uc.findAllClasses(teacherUser.id, teacherUser.school.id);
 
-					expect(groupService.findGroups).toHaveBeenCalledWith<[GroupFilter]>({ schoolId: teacherUser.school.id });
+					expect(groupService.findGroups).toHaveBeenCalledWith<[GroupFilter]>({
+						schoolId: teacherUser.school.id,
+						groupTypes: [GroupTypes.CLASS],
+					});
 				});
 			});
 

--- a/apps/server/src/modules/group/uc/class-group.uc.ts
+++ b/apps/server/src/modules/group/uc/class-group.uc.ts
@@ -15,7 +15,7 @@ import { Pagination, Permission, SortOrder } from '@shared/domain/interface';
 import { EntityId } from '@shared/domain/types';
 import { System, SystemService } from '@src/modules/system';
 import { ClassRequestContext, SchoolYearQueryType } from '../controller/dto/interface';
-import { Group, GroupFilter } from '../domain';
+import { Group, GroupFilter, GroupTypes } from '../domain';
 import { UnknownQueryTypeLoggableException } from '../loggable';
 import { GroupService } from '../service';
 import { ClassInfoDto, ResolvedGroupUser } from './dto';
@@ -217,7 +217,7 @@ export class ClassGroupUc {
 	}
 
 	private async findGroupsForSchool(schoolId: EntityId): Promise<ClassInfoDto[]> {
-		const filter: GroupFilter = { schoolId };
+		const filter: GroupFilter = { schoolId, groupTypes: [GroupTypes.CLASS] };
 
 		const groups: Page<Group> = await this.groupService.findGroups(filter);
 
@@ -227,7 +227,7 @@ export class ClassGroupUc {
 	}
 
 	private async findGroupsForUser(userId: EntityId): Promise<ClassInfoDto[]> {
-		const filter: GroupFilter = { userId };
+		const filter: GroupFilter = { userId, groupTypes: [GroupTypes.CLASS] };
 
 		const groups: Page<Group> = await this.groupService.findGroups(filter);
 


### PR DESCRIPTION
# Description
Within NBC classes are also known as groups. Within that setting, group belonging to the new RoomMember(ship) Entity are also shown there. As for now the business case, where and how to show these new groups is not finally decided, we should filter the classes/groups for only the class type and remove the ones, belonging to the new type rooms.
<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the begining of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->
BC-8362
## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->
- filter groups for group type class status in BE

## Approval for review

- [x] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
