### PR TITLE
BC-8510 - Wrong handling of WITH_TLDRAW2 by ConfigModule

### DIFF
--- a/apps/server/src/modules/board/board-collaboration.config.ts
+++ b/apps/server/src/modules/board/board-collaboration.config.ts
@@ -1,6 +1,7 @@
 import { Configuration } from '@hpi-schul-cloud/commons';
 import { JwtAuthGuardConfig } from '@infra/auth-guard';
 import { Algorithm } from 'jsonwebtoken';
+import { getTldrawClientConfig } from '../tldraw-client';
 
 export interface BoardCollaborationConfig extends JwtAuthGuardConfig {
 	NEST_LOG_LEVEL: string;
@@ -13,6 +14,7 @@ const boardCollaborationConfig: BoardCollaborationConfig = {
 	JWT_PUBLIC_KEY: (Configuration.get('JWT_PUBLIC_KEY') as string).replace(/\\n/g, '\n'),
 	JWT_SIGNING_ALGORITHM: Configuration.get('JWT_SIGNING_ALGORITHM') as Algorithm,
 	SC_DOMAIN: Configuration.get('SC_DOMAIN') as string,
+	...getTldrawClientConfig(),
 };
 
 export const config = () => boardCollaborationConfig;

--- a/apps/server/src/modules/tldraw-client/interface/tldraw-client-config.interface.ts
+++ b/apps/server/src/modules/tldraw-client/interface/tldraw-client-config.interface.ts
@@ -1,5 +1,4 @@
 export interface TldrawClientConfig {
 	TLDRAW_ADMIN_API_CLIENT_BASE_URL: string;
 	TLDRAW_ADMIN_API_CLIENT_API_KEY: string;
-	WITH_TLDRAW2: boolean;
 }

--- a/apps/server/src/modules/tldraw-client/service/drawing-element-adapter.service.spec.ts
+++ b/apps/server/src/modules/tldraw-client/service/drawing-element-adapter.service.spec.ts
@@ -49,14 +49,12 @@ describe(DrawingElementAdapterService.name, () => {
 	});
 
 	describe('deleteDrawingBinData', () => {
-		describe('when WITH_TLDRAW2 env var is true', () => {
+		describe('when deleteDrawingBinData is called', () => {
 			const setup = () => {
 				const apiKey = 'a4a20e6a-8036-4603-aba6-378006fedce2';
 				const baseUrl = 'http://localhost:3349';
-				const WITH_TLDRAW2 = true;
 
 				configService.get.mockReturnValueOnce(baseUrl);
-				configService.get.mockReturnValueOnce(WITH_TLDRAW2);
 				configService.get.mockReturnValueOnce(apiKey);
 				httpService.delete.mockReturnValue(
 					of(
@@ -77,38 +75,6 @@ describe(DrawingElementAdapterService.name, () => {
 				await service.deleteDrawingBinData('test');
 
 				expect(httpService.delete).toHaveBeenCalledWith(`${baseUrl}/api/tldraw-document/test`, {
-					headers: { 'X-Api-Key': apiKey, Accept: 'Application/json' },
-				});
-			});
-		});
-
-		describe('when WITH_TLDRAW2 env var is false', () => {
-			const setup = () => {
-				const apiKey = 'a4a20e6a-8036-4603-aba6-378006fedce2';
-				const baseUrl = 'http://localhost:3349';
-				const WITH_TLDRAW2 = false;
-				configService.get.mockReturnValueOnce(baseUrl);
-				configService.get.mockReturnValueOnce(WITH_TLDRAW2);
-				configService.get.mockReturnValueOnce(apiKey);
-				httpService.delete.mockReturnValue(
-					of(
-						axiosResponseFactory.build({
-							data: '',
-							status: HttpStatus.OK,
-							statusText: 'OK',
-						})
-					)
-				);
-
-				return { apiKey, baseUrl };
-			};
-
-			it('should call axios delete method', async () => {
-				const { apiKey, baseUrl } = setup();
-
-				await service.deleteDrawingBinData('test');
-
-				expect(httpService.delete).toHaveBeenCalledWith(`${baseUrl}/api/v3/tldraw-document/test`, {
 					headers: { 'X-Api-Key': apiKey, Accept: 'Application/json' },
 				});
 			});

--- a/apps/server/src/modules/tldraw-client/service/drawing-element-adapter.service.ts
+++ b/apps/server/src/modules/tldraw-client/service/drawing-element-adapter.service.ts
@@ -17,8 +17,7 @@ export class DrawingElementAdapterService {
 
 	async deleteDrawingBinData(parentId: string): Promise<void> {
 		const baseUrl = this.configService.get<string>('TLDRAW_ADMIN_API_CLIENT_BASE_URL');
-		const isTlDraw2 = this.configService.get<boolean>('WITH_TLDRAW2');
-		const endpointUrl = isTlDraw2 ? '/api/tldraw-document' : '/api/v3/tldraw-document';
+		const endpointUrl = '/api/tldraw-document';
 		const tldrawDocumentEndpoint = new URL(endpointUrl, baseUrl).toString();
 
 		await firstValueFrom(this.httpService.delete(`${tldrawDocumentEndpoint}/${parentId}`, this.defaultHeaders()));

--- a/apps/server/src/modules/tldraw-client/tldraw-client.config.spec.ts
+++ b/apps/server/src/modules/tldraw-client/tldraw-client.config.spec.ts
@@ -20,12 +20,10 @@ describe(getTldrawClientConfig.name, () => {
 
 			Configuration.set('TLDRAW_ADMIN_API_CLIENT__BASE_URL', baseUrl);
 			Configuration.set('TLDRAW_ADMIN_API_CLIENT__API_KEY', apiKey);
-			Configuration.set('WITH_TLDRAW2', true);
 
 			const expectedConfig = {
 				TLDRAW_ADMIN_API_CLIENT_BASE_URL: baseUrl,
 				TLDRAW_ADMIN_API_CLIENT_API_KEY: apiKey,
-				WITH_TLDRAW2: true,
 			};
 
 			return { expectedConfig };

--- a/apps/server/src/modules/tldraw-client/tldraw-client.config.ts
+++ b/apps/server/src/modules/tldraw-client/tldraw-client.config.ts
@@ -5,6 +5,5 @@ export const getTldrawClientConfig = (): TldrawClientConfig => {
 	return {
 		TLDRAW_ADMIN_API_CLIENT_BASE_URL: Configuration.get('TLDRAW_ADMIN_API_CLIENT__BASE_URL') as string,
 		TLDRAW_ADMIN_API_CLIENT_API_KEY: Configuration.get('TLDRAW_ADMIN_API_CLIENT__API_KEY') as string,
-		WITH_TLDRAW2: Configuration.get('WITH_TLDRAW2') as boolean,
 	};
 };

--- a/config/default.schema.json
+++ b/config/default.schema.json
@@ -1648,11 +1648,6 @@
 			"default": "http://localhost:3349",
 			"description": "Address for tldraw management app"
 		},
-		"WITH_TLDRAW2": {
-			"type": "boolean",
-			"default": false,
-			"description": "Enables tldraw2 feature"
-		},
 		"SCHULCONNEX_CLIENT": {
 			"type": "object",
 			"description": "Configuration of the schulcloud's schulconnex client.",


### PR DESCRIPTION
# Description
if you do not pull the config to the forroot it does not get validated. if you config is not validated it gets to process.env as a fallback in process.env everything is a string, thus a thought to be boolean will be "false" resulting in if ("false") to be true

in this particular case, it was WITH_TLDRAW2 that lead to this issue


## Links to Tickets or other pull requests
- https://ticketsystem.dbildungscloud.de/browse/BC-8510

<!--
## Changes
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Approval for review

- [x] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

