### PR TITLE
BC-8499 validate tldraw config in forRoot for boardcollabmodule

### DIFF
--- a/apps/server/src/modules/board/board-collaboration.config.ts
+++ b/apps/server/src/modules/board/board-collaboration.config.ts
@@ -1,6 +1,7 @@
 import { Configuration } from '@hpi-schul-cloud/commons';
 import { JwtAuthGuardConfig } from '@infra/auth-guard';
 import { Algorithm } from 'jsonwebtoken';
+import { getTldrawClientConfig } from '@modules/tldraw-client';
 
 export interface BoardCollaborationConfig extends JwtAuthGuardConfig {
 	NEST_LOG_LEVEL: string;
@@ -13,6 +14,7 @@ const boardCollaborationConfig: BoardCollaborationConfig = {
 	JWT_PUBLIC_KEY: (Configuration.get('JWT_PUBLIC_KEY') as string).replace(/\\n/g, '\n'),
 	JWT_SIGNING_ALGORITHM: Configuration.get('JWT_SIGNING_ALGORITHM') as Algorithm,
 	SC_DOMAIN: Configuration.get('SC_DOMAIN') as string,
+	...getTldrawClientConfig(),
 };
 
 export const config = () => boardCollaborationConfig;


### PR DESCRIPTION
if you do not pull the config to the forroot it does not get validated. if you config is not validated it gets to process.env as a fallback in process.env everything is a string, thus a thought to be boolean will be "false" resulting in if ("false") to be true

in this particular case, it was WITH_TLDRAW2 that lead to this issue

# Description
<!--
  This is a template to add as much information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should be hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->

<!--
## Changes
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Approval for review

- [ ] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

