### PR TITLE
BC-8746 - fix add members

### DIFF
--- a/apps/server/src/modules/school/api/dto/response/school-user.response.ts
+++ b/apps/server/src/modules/school/api/dto/response/school-user.response.ts
@@ -1,18 +1,17 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { PaginationResponse } from '@shared/controller';
 
 export class SchoolUserResponse {
 	@ApiProperty()
-	firstName!: string;
+	public firstName!: string;
 
 	@ApiProperty()
-	lastName!: string;
+	public lastName!: string;
 
 	@ApiProperty()
-	schoolName!: string;
+	public schoolName!: string;
 
 	@ApiProperty()
-	id!: string;
+	public id!: string;
 
 	constructor(props: SchoolUserResponse) {
 		this.id = props.id;
@@ -22,9 +21,8 @@ export class SchoolUserResponse {
 	}
 }
 
-export class SchoolUserListResponse extends PaginationResponse<SchoolUserResponse[]> {
-	constructor(data: SchoolUserResponse[], total: number, skip?: number, limit?: number) {
-		super(total, skip, limit);
+export class SchoolUserListResponse {
+	constructor(data: SchoolUserResponse[]) {
 		this.data = data;
 	}
 

--- a/apps/server/src/modules/school/api/dto/response/school.response.ts
+++ b/apps/server/src/modules/school/api/dto/response/school.response.ts
@@ -26,8 +26,8 @@ export class SchoolResponse {
 	@ApiPropertyOptional({ type: SchoolYearResponse })
 	currentYear?: SchoolYearResponse;
 
-	@ApiProperty({ type: FederalStateResponse })
-	federalState: FederalStateResponse;
+	@ApiPropertyOptional({ type: FederalStateResponse })
+	federalState?: FederalStateResponse;
 
 	@ApiPropertyOptional()
 	county?: CountyResponse;

--- a/apps/server/src/modules/school/api/mapper/school-user.response.mapper.ts
+++ b/apps/server/src/modules/school/api/mapper/school-user.response.mapper.ts
@@ -1,4 +1,3 @@
-import { PaginationParams } from '@shared/controller';
 import { Page, UserDO } from '@shared/domain/domainobject';
 import { SchoolUserListResponse, SchoolUserResponse } from '../dto/response/school-user.response';
 
@@ -14,9 +13,9 @@ export class SchoolUserResponseMapper {
 		return res;
 	}
 
-	static mapToListResponse(users: Page<UserDO>, pagination?: PaginationParams): SchoolUserListResponse {
+	public static mapToListResponse(users: Page<UserDO>): SchoolUserListResponse {
 		const data: SchoolUserResponse[] = users.data.map((user) => this.mapToResponse(user));
-		const response = new SchoolUserListResponse(data, users.total, pagination?.skip, pagination?.limit);
+		const response = new SchoolUserListResponse(data);
 
 		return response;
 	}

--- a/apps/server/src/modules/school/api/mapper/school.response.mapper.ts
+++ b/apps/server/src/modules/school/api/mapper/school.response.mapper.ts
@@ -10,7 +10,9 @@ export class SchoolResponseMapper {
 	public static mapToResponse(school: School, years: YearsResponse): SchoolResponse {
 		const schoolProps = school.getProps();
 
-		const federalState = FederalStateResponseMapper.mapToResponse(schoolProps.federalState);
+		const federalState = schoolProps.federalState
+			? FederalStateResponseMapper.mapToResponse(schoolProps.federalState)
+			: undefined;
 		const currentYear = schoolProps.currentYear && SchoolYearResponseMapper.mapToResponse(schoolProps.currentYear);
 		const features = Array.from(schoolProps.features);
 		const county = schoolProps.county && CountyResponseMapper.mapToResponse(schoolProps.county);

--- a/apps/server/src/modules/school/api/test/school-users.api.spec.ts
+++ b/apps/server/src/modules/school/api/test/school-users.api.spec.ts
@@ -118,7 +118,6 @@ describe('School Controller (API)', () => {
 				const body = response.body as SchoolUserListResponse;
 
 				expect(response.status).toEqual(HttpStatus.OK);
-				expect(body.total).toEqual(publicTeachersOfSchool.length);
 				expect(body.data).toEqual(
 					expect.arrayContaining([
 						...publicTeachersOfSchool.map((teacher) => {
@@ -131,6 +130,7 @@ describe('School Controller (API)', () => {
 						}),
 					])
 				);
+				expect(body.data.length).toEqual(publicTeachersOfSchool.length);
 			});
 		});
 

--- a/apps/server/src/modules/school/domain/do/school.spec.ts
+++ b/apps/server/src/modules/school/domain/do/school.spec.ts
@@ -116,6 +116,16 @@ describe('School', () => {
 				expect(school.getProps().county).toEqual(county);
 			});
 		});
+
+		describe('when school has no defined federalState', () => {
+			it('should throw `County cannot be set without a federal state being assigned to the school.` error', () => {
+				const school = schoolFactory.build({ federalState: undefined });
+
+				expect(() => school.updateCounty('abc')).toThrowError(
+					'County cannot be set without a federal state being assigned to the school.'
+				);
+			});
+		});
 	});
 
 	describe('updateOfficialSchoolNumber', () => {

--- a/apps/server/src/modules/school/domain/do/school.ts
+++ b/apps/server/src/modules/school/domain/do/school.ts
@@ -84,6 +84,9 @@ export class School extends DomainObject<SchoolProps> {
 		if (county) {
 			throw new ValidationError('County cannot be updated, once it is set.');
 		}
+		if (federalState === undefined) {
+			throw new ValidationError('County cannot be set without a federal state being assigned to the school.');
+		}
 		const { counties } = federalState.getProps();
 		const countyObject = counties?.find((item) => item.id === countyId);
 
@@ -148,7 +151,7 @@ export interface SchoolProps extends AuthorizableObject {
 	inMaintenanceSince?: Date;
 	inUserMigration?: boolean;
 	currentYear?: SchoolYear;
-	federalState: FederalState;
+	federalState?: FederalState;
 	county?: County;
 	purpose?: SchoolPurpose;
 	features: Set<SchoolFeature>;

--- a/apps/server/src/modules/school/repo/mikro-orm/mapper/school.entity.mapper.ts
+++ b/apps/server/src/modules/school/repo/mikro-orm/mapper/school.entity.mapper.ts
@@ -12,7 +12,7 @@ import { SchoolYearEntityMapper } from './school-year.entity.mapper';
 export class SchoolEntityMapper {
 	public static mapToDo(entity: SchoolEntity): School {
 		const currentYear = entity.currentYear && SchoolYearEntityMapper.mapToDo(entity.currentYear);
-		const federalState = FederalStateEntityMapper.mapToDo(entity.federalState);
+		const federalState = entity.federalState ? FederalStateEntityMapper.mapToDo(entity.federalState) : undefined;
 		const features = new Set(entity.features);
 		const county = entity.county && CountyEmbeddableMapper.mapToDo(entity.county);
 		const systemIds = entity.systems.getItems().map((system) => system.id);


### PR DESCRIPTION
# Description
Users are not able to add members to a room, if the database contains schools that have no federalState defined.

## Links to Tickets or other pull requests
BC-8746
https://github.com/hpi-schul-cloud/nuxt-client/pull/3503

## Changes
* required property **federalState** for **schools** is now optional
* pagination information is not any longer part of the getTeachersResponse

## Approval for review

- [x] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

