### PR TITLE
EW-1158: New TSP Sync now sets lastSyncedAt.

### DIFF
--- a/apps/server/src/modules/provisioning/service/tsp-provisioning.service.ts
+++ b/apps/server/src/modules/provisioning/service/tsp-provisioning.service.ts
@@ -225,6 +225,7 @@ export class TspProvisioningService {
 				birthday: externalUser.birthday,
 				externalId: externalUser.externalId,
 				secondarySchools: [],
+				lastSyncedAt: new Date(),
 			});
 
 			this.createTspConsent(newUser);
@@ -238,6 +239,7 @@ export class TspProvisioningService {
 		existingUser.lastName = externalUser.lastName || existingUser.lastName;
 		existingUser.email = externalUser.email || existingUser.email;
 		existingUser.birthday = externalUser.birthday;
+		existingUser.lastSyncedAt = new Date();
 
 		return existingUser;
 	}

--- a/apps/server/src/modules/user/domain/do/user.do.ts
+++ b/apps/server/src/modules/user/domain/do/user.do.ts
@@ -5,9 +5,9 @@ import { EntityId } from '@shared/domain/types';
 import { UserSourceOptions } from './user-source-options.do';
 
 export class SecondarySchoolReference {
-	schoolId: EntityId;
+	public schoolId: EntityId;
 
-	role: RoleReference;
+	public role: RoleReference;
 
 	constructor(props: SecondarySchoolReference) {
 		this.schoolId = props.schoolId;
@@ -16,57 +16,59 @@ export class SecondarySchoolReference {
 }
 
 export class UserDo extends BaseDO {
-	createdAt?: Date;
+	public createdAt?: Date;
 
-	updatedAt?: Date;
+	public updatedAt?: Date;
 
-	email: string;
+	public email: string;
 
-	firstName: string;
+	public firstName: string;
 
-	lastName: string;
+	public lastName: string;
 
-	preferredName?: string;
+	public preferredName?: string;
 
-	roles: RoleReference[];
+	public roles: RoleReference[];
 
-	schoolId: EntityId;
+	public schoolId: EntityId;
 
-	schoolName?: string;
+	public schoolName?: string;
 
-	secondarySchools: SecondarySchoolReference[];
+	public secondarySchools: SecondarySchoolReference[];
 
-	ldapDn?: string;
+	public ldapDn?: string;
 
-	externalId?: string;
+	public externalId?: string;
 
-	importHash?: string;
+	public importHash?: string;
 
-	firstNameSearchValues?: string[];
+	public firstNameSearchValues?: string[];
 
-	lastNameSearchValues?: string[];
+	public lastNameSearchValues?: string[];
 
-	emailSearchValues?: string[];
+	public emailSearchValues?: string[];
 
-	language?: LanguageType;
+	public language?: LanguageType;
 
-	forcePasswordChange?: boolean;
+	public forcePasswordChange?: boolean;
 
-	discoverable?: boolean;
+	public discoverable?: boolean;
 
-	preferences?: Record<string, unknown>;
+	public preferences?: Record<string, unknown>;
 
-	lastLoginSystemChange?: Date;
+	public lastLoginSystemChange?: Date;
 
-	outdatedSince?: Date;
+	public outdatedSince?: Date;
 
-	previousExternalId?: string;
+	public previousExternalId?: string;
 
-	birthday?: Date;
+	public birthday?: Date;
 
-	consent?: Consent;
+	public consent?: Consent;
 
-	sourceOptions?: UserSourceOptions;
+	public sourceOptions?: UserSourceOptions;
+
+	public lastSyncedAt?: Date;
 
 	constructor(domainObject: UserDo) {
 		super(domainObject.id);
@@ -97,5 +99,6 @@ export class UserDo extends BaseDO {
 		this.birthday = domainObject.birthday;
 		this.consent = domainObject.consent;
 		this.sourceOptions = domainObject.sourceOptions;
+		this.lastSyncedAt = domainObject.lastSyncedAt;
 	}
 }

--- a/apps/server/src/modules/user/repo/mikro-orm/user-do.repo.ts
+++ b/apps/server/src/modules/user/repo/mikro-orm/user-do.repo.ts
@@ -165,6 +165,7 @@ export class UserDORepo extends BaseDORepo<UserDo, User> {
 			previousExternalId: entity.previousExternalId,
 			birthday: entity.birthday,
 			sourceOptions: entity.sourceOptions ? new UserSourceOptions({ tspUid: entity.sourceOptions.tspUid }) : undefined,
+			lastSyncedAt: entity.lastSyncedAt,
 		});
 
 		if (entity.roles.isInitialized()) {
@@ -213,6 +214,7 @@ export class UserDORepo extends BaseDORepo<UserDo, User> {
 			sourceOptions: entityDO.sourceOptions
 				? new UserSourceOptionsEntity({ tspUid: entityDO.sourceOptions.tspUid })
 				: undefined,
+			lastSyncedAt: entityDO.lastSyncedAt,
 		};
 	}
 


### PR DESCRIPTION
# Description
New TSP Sync now sets lastSyncedAt during syncs and ad hoc provisioning.

## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/EW-1158
<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->

## Approval for review

- [x] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

