### PR TITLE
EW-1170 fixed mapping of Etherpad title and description in cc export

### DIFF
--- a/apps/server/src/modules/common-cartridge/service/common-cartridge.mapper.spec.ts
+++ b/apps/server/src/modules/common-cartridge/service/common-cartridge.mapper.spec.ts
@@ -156,9 +156,7 @@ describe('CommonCartridgeExportMapper', () => {
 				expect(result).toEqual({
 					type: CommonCartridgeResourceType.WEB_LINK,
 					identifier: `i${lessonContent.id ?? ''}`,
-					title: `${(lessonContent.content as ComponentEtherpadPropsDto).title} - ${
-						(lessonContent.content as ComponentEtherpadPropsDto).description
-					}`,
+					title: `${lessonContent.title} - ${(lessonContent.content as ComponentEtherpadPropsDto).description}`,
 					url: (lessonContent.content as ComponentEtherpadPropsDto).url,
 				});
 			});

--- a/apps/server/src/modules/common-cartridge/service/common-cartridge.mapper.ts
+++ b/apps/server/src/modules/common-cartridge/service/common-cartridge.mapper.ts
@@ -80,9 +80,7 @@ export class CommonCartridgeExportMapper {
 				return {
 					type: CommonCartridgeResourceType.WEB_LINK,
 					identifier: createIdentifier(lessonContent.id),
-					title: `${(lessonContent.content as ComponentEtherpadPropsDto).title} - ${
-						(lessonContent.content as ComponentEtherpadPropsDto).description
-					}`,
+					title: `${lessonContent.title} - ${(lessonContent.content as ComponentEtherpadPropsDto).description}`,
 					url: (lessonContent.content as ComponentEtherpadPropsDto).url,
 				};
 			case LessonContentDtoComponentValues.RESOURCES: {

--- a/apps/server/src/modules/common-cartridge/service/common-cartridge.mapper.ts
+++ b/apps/server/src/modules/common-cartridge/service/common-cartridge.mapper.ts
@@ -80,7 +80,9 @@ export class CommonCartridgeExportMapper {
 				return {
 					type: CommonCartridgeResourceType.WEB_LINK,
 					identifier: createIdentifier(lessonContent.id),
-					title: `${lessonContent.title} - ${(lessonContent.content as ComponentEtherpadPropsDto).description}`,
+					title: (lessonContent.content as ComponentEtherpadPropsDto).description
+						? `${lessonContent.title} - ${(lessonContent.content as ComponentEtherpadPropsDto).description}`
+						: lessonContent.title,
 					url: (lessonContent.content as ComponentEtherpadPropsDto).url,
 				};
 			case LessonContentDtoComponentValues.RESOURCES: {


### PR DESCRIPTION
# Description
A bug of mapping the title & description of an Etherpad element of topic by exporting the course via microservice was fixed.

## Links to Tickets or other pull requests
(EW-1170)[https://ticketsystem.dbildungscloud.de/browse/EW-1170]

<!--
## Changes
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Approval for review

- [ ] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

