### PR TITLE
EW-1188 Fix consent creation for tsp users

### DIFF
--- a/apps/server/src/modules/provisioning/service/tsp-provisioning.service.spec.ts
+++ b/apps/server/src/modules/provisioning/service/tsp-provisioning.service.spec.ts
@@ -9,7 +9,7 @@ import { RoleName, RoleService } from '@modules/role';
 import { roleDtoFactory, roleFactory } from '@modules/role/testing';
 import { SchoolService } from '@modules/school';
 import { schoolFactory } from '@modules/school/testing';
-import { UserService } from '@modules/user';
+import { ParentConsent, UserConsent, UserService } from '@modules/user';
 import { userDoFactory } from '@modules/user/testing';
 import { Test, TestingModule } from '@nestjs/testing';
 import { NotFoundLoggableException } from '@shared/common/loggable-exception';
@@ -638,6 +638,149 @@ describe('TspProvisioningService', () => {
 
 				await expect(sut.provisionUser(data, school)).rejects.toThrow(BadDataLoggableException);
 				expect(userServiceMock.deleteUser).toHaveBeenCalledWith(user.id);
+			});
+		});
+
+		describe('when user has incomplete consent', () => {
+			const setup = (parentConsents: ParentConsent[] | undefined, userConsent: UserConsent | undefined) => {
+				const school = schoolFactory.build();
+				const data = oauthDataDtoFactory.build({
+					system: provisioningSystemDtoFactory.build(),
+					externalUser: externalUserDtoFactory.build(),
+					externalSchool: externalSchoolDtoFactory.build(),
+				});
+				const user = userDoFactory.build({
+					id: faker.string.uuid(),
+					consent: {
+						parentConsents,
+						userConsent,
+					},
+				});
+
+				userServiceMock.findByExternalId.mockResolvedValueOnce(user);
+				userServiceMock.save.mockResolvedValueOnce(user);
+				schoolServiceMock.getSchools.mockResolvedValueOnce([school]);
+				roleServiceMock.findByNames.mockResolvedValueOnce([]);
+
+				return { data, school };
+			};
+
+			it('should create consent if parent consent is empty and user consent is undefined', async () => {
+				const { data, school } = setup([], undefined);
+
+				await sut.provisionUser(data, school);
+
+				expect(userServiceMock.save).toHaveBeenCalledTimes(1);
+
+				expect(userServiceMock.save.mock.calls[0][0].consent?.parentConsents?.[0]).toMatchObject({
+					form: 'digital',
+					privacyConsent: true,
+					termsOfUseConsent: true,
+					dateOfPrivacyConsent: expect.any(Date),
+					dateOfTermsOfUseConsent: expect.any(Date),
+				});
+
+				expect(userServiceMock.save.mock.calls[0][0].consent?.userConsent).toMatchObject({
+					form: 'digital',
+					privacyConsent: true,
+					termsOfUseConsent: true,
+					dateOfPrivacyConsent: expect.any(Date),
+					dateOfTermsOfUseConsent: expect.any(Date),
+				});
+			});
+
+			it('should create consent if user consent exists but parent consent is missing', async () => {
+				const { data, school } = setup(undefined, {
+					form: 'digital',
+					privacyConsent: true,
+					termsOfUseConsent: true,
+					dateOfPrivacyConsent: new Date(),
+					dateOfTermsOfUseConsent: new Date(),
+				});
+
+				await sut.provisionUser(data, school);
+
+				expect(userServiceMock.save).toHaveBeenCalledTimes(1);
+
+				expect(userServiceMock.save.mock.calls[0][0].consent?.parentConsents?.[0]).toMatchObject({
+					form: 'digital',
+					privacyConsent: true,
+					termsOfUseConsent: true,
+					dateOfPrivacyConsent: expect.any(Date),
+					dateOfTermsOfUseConsent: expect.any(Date),
+				});
+			});
+
+			it('should create consent if parent consent exists but user consent is missing', async () => {
+				const { data, school } = setup(
+					[
+						{
+							id: faker.string.uuid(),
+							form: 'digital',
+							privacyConsent: true,
+							termsOfUseConsent: true,
+							dateOfPrivacyConsent: new Date(),
+							dateOfTermsOfUseConsent: new Date(),
+						},
+					],
+					undefined
+				);
+
+				await sut.provisionUser(data, school);
+
+				expect(userServiceMock.save).toHaveBeenCalledTimes(1);
+
+				expect(userServiceMock.save.mock.calls[0][0].consent?.userConsent).toMatchObject({
+					form: 'digital',
+					privacyConsent: true,
+					termsOfUseConsent: true,
+					dateOfPrivacyConsent: expect.any(Date),
+					dateOfTermsOfUseConsent: expect.any(Date),
+				});
+			});
+
+			it('should not create a new consent if both parent consent and user consent exist', async () => {
+				const currentDate = new Date();
+				const { data, school } = setup(
+					[
+						{
+							id: faker.string.uuid(),
+							form: 'digital',
+							privacyConsent: true,
+							termsOfUseConsent: true,
+							dateOfPrivacyConsent: currentDate,
+							dateOfTermsOfUseConsent: currentDate,
+						},
+					],
+					{
+						form: 'digital',
+						privacyConsent: true,
+						termsOfUseConsent: true,
+						dateOfPrivacyConsent: currentDate,
+						dateOfTermsOfUseConsent: currentDate,
+					}
+				);
+
+				await sut.provisionUser(data, school);
+
+				expect(userServiceMock.save).toHaveBeenCalledTimes(1);
+
+				expect(userServiceMock.save.mock.calls[0][0].consent?.parentConsents?.[0]).toMatchObject({
+					id: expect.any(String),
+					form: 'digital',
+					privacyConsent: true,
+					termsOfUseConsent: true,
+					dateOfPrivacyConsent: currentDate,
+					dateOfTermsOfUseConsent: currentDate,
+				});
+
+				expect(userServiceMock.save.mock.calls[0][0].consent?.userConsent).toMatchObject({
+					form: 'digital',
+					privacyConsent: true,
+					termsOfUseConsent: true,
+					dateOfPrivacyConsent: currentDate,
+					dateOfTermsOfUseConsent: currentDate,
+				});
 			});
 		});
 	});

--- a/apps/server/src/modules/provisioning/service/tsp-provisioning.service.ts
+++ b/apps/server/src/modules/provisioning/service/tsp-provisioning.service.ts
@@ -246,8 +246,11 @@ export class TspProvisioningService {
 		existingUser.lastName = externalUser.lastName || existingUser.lastName;
 		existingUser.email = externalUser.email || existingUser.email;
 		existingUser.birthday = externalUser.birthday || existingUser.birthday || new Date();
-		existingUser.consent = existingUser.consent || this.createTspConsent();
 		existingUser.lastSyncedAt = new Date();
+
+		if (!existingUser.consent || !existingUser.consent.parentConsents?.length || !existingUser.consent.userConsent) {
+			existingUser.consent = this.createTspConsent();
+		}
 
 		return existingUser;
 	}


### PR DESCRIPTION
# Description
The consent creation for tsp users has been adjusted so that consent is created if user consent or parent consent is missing.

## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/EW-1188

<!--
## Changes
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Approval for review

- [x] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

