### PR TITLE
BC-9478 - Adjust max-old-space-size to memory limits from pods

### DIFF
--- a/ansible/roles/media-licenses/templates/vidis-sync-cronjob-configmap.yml.j2
+++ b/ansible/roles/media-licenses/templates/vidis-sync-cronjob-configmap.yml.j2
@@ -6,6 +6,6 @@ metadata:
   labels:
     app: vidis-sync-cronjob
 data:
-  NODE_OPTIONS: "--max-old-space-size=3072"
+  NODE_OPTIONS: "--max-old-space-size=1536"
   NEST_LOG_LEVEL: "error"
   EXIT_ON_ERROR: "true"

--- a/ansible/roles/moin-schule-sync/templates/moin-schule-users-deletion-queueing-cronjob-configmap.yml.j2
+++ b/ansible/roles/moin-schule-sync/templates/moin-schule-users-deletion-queueing-cronjob-configmap.yml.j2
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: moin-schule-users-deletion-queueing-cronjob
 data:
-  NODE_OPTIONS: "--max-old-space-size=3072"
+  NODE_OPTIONS: "--max-old-space-size=1536"
   NEST_LOG_LEVEL: "error"
   EXIT_ON_ERROR: "true"
   SC_DOMAIN: "{{ DOMAIN }}"

--- a/ansible/roles/moin-schule-sync/templates/moin-schule-users-sync-cronjob-configmap.yml.j2
+++ b/ansible/roles/moin-schule-sync/templates/moin-schule-users-sync-cronjob-configmap.yml.j2
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: moin-schule-users-sync-cronjob
 data:
-  NODE_OPTIONS: "--max-old-space-size=3072"
+  NODE_OPTIONS: "--max-old-space-size=1536"
   NEST_LOG_LEVEL: "error"
   EXIT_ON_ERROR: "true"
   SC_DOMAIN: "{{ DOMAIN }}"

--- a/ansible/roles/schulcloud-server-core/templates/configmap.yml.j2
+++ b/ansible/roles/schulcloud-server-core/templates/configmap.yml.j2
@@ -9,7 +9,7 @@ metadata:
 data:
   # general
   NODE_ENV: "production"
-  NODE_OPTIONS: "--max-old-space-size=2048"
+  NODE_OPTIONS: "--max-old-space-size=1536"
   SC_TITLE: "{{ SC_TITLE }}"
   SC_THEME: "{{ SC_THEME }}"
   SC_SHORTNAME: "{{ SC_SHORTNAME }}"

--- a/ansible/roles/schulcloud-server-core/templates/data-deletion-trigger-cronjob-configmap.yml.j2
+++ b/ansible/roles/schulcloud-server-core/templates/data-deletion-trigger-cronjob-configmap.yml.j2
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: data-deletion-trigger-cronjob
 data:
-  NODE_OPTIONS: "--max-old-space-size=3072"
+  NODE_OPTIONS: "--max-old-space-size=1536"
   NEST_LOG_LEVEL: "error"
   EXIT_ON_ERROR: "true"
   SC_DOMAIN: "{{ DOMAIN }}"

--- a/ansible/roles/schulcloud-server-core/templates/data-deletion-trigger-failed-cronjob-configmap.yml.j2
+++ b/ansible/roles/schulcloud-server-core/templates/data-deletion-trigger-failed-cronjob-configmap.yml.j2
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: data-deletion-trigger-failed-cronjob
 data:
-  NODE_OPTIONS: "--max-old-space-size=3072"
+  NODE_OPTIONS: "--max-old-space-size=1536"
   NEST_LOG_LEVEL: "error"
   EXIT_ON_ERROR: "true"
   SC_DOMAIN: "{{ DOMAIN }}"

--- a/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-cronjob-configmap.yml.j2
+++ b/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-cronjob-configmap.yml.j2
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: api-tsp-sync-cronjob
 data:
-  NODE_OPTIONS: "--max-old-space-size=3072"
+  NODE_OPTIONS: "--max-old-space-size=1536"
   NEST_LOG_LEVEL: "{{ NEST_LOG_LEVEL }}"
   EXIT_ON_ERROR: "true"
   FEATURE_IDENTITY_MANAGEMENT_ENABLED: "{{ FEATURE_IDENTITY_MANAGEMENT_ENABLED }}"

--- a/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-init-configmap.yml.j2
+++ b/ansible/roles/schulcloud-server-tspsync/templates/api-tsp-sync-init-configmap.yml.j2
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: api-tsp-sync-init
 data:
-  NODE_OPTIONS: "--max-old-space-size=3072"
+  NODE_OPTIONS: "--max-old-space-size=1536"
   NEST_LOG_LEVEL: "{{ NEST_LOG_LEVEL }}"
   EXIT_ON_ERROR: "true"
   FEATURE_IDENTITY_MANAGEMENT_ENABLED: "{{ FEATURE_IDENTITY_MANAGEMENT_ENABLED }}"


### PR DESCRIPTION
# Description
If the max-old-space-size is set to an ram size in MB who is more then the ram size lime set at dof_app_deploy for the container of an pod who is run then it's not good.
So this PR adjust the max-old-space-size to the memory limit set at dof_app_deploy for the container of an pod who is run the software with this option.

## Links to Tickets or other pull requests
* https://ticketsystem.dbildungscloud.de/browse/BC-9478

<!--
## Changes
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Approval for review

- [x] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

