### PR TITLE
BC-9495 - During first load the rooms page /rooms takes longer then expected

### DIFF
--- a/apps/server/src/modules/room-membership/repo/entity/room-membership.entity.ts
+++ b/apps/server/src/modules/room-membership/repo/entity/room-membership.entity.ts
@@ -11,6 +11,7 @@ export class RoomMembershipEntity extends BaseEntityWithTimestamps implements Ro
 	@Property({ type: ObjectIdType, fieldName: 'room' })
 	roomId!: EntityId;
 
+	@Index()
 	@Property({ type: ObjectIdType, fieldName: 'userGroup' })
 	userGroupId!: EntityId;
 


### PR DESCRIPTION
# Description
When accessing the page "/rooms" the rooms which the user can access are loaded and filtered in the background. Within the process the `userGroupId` is requested, but this property does not have an index, which is the source of the "delay".

<!--
  This is a template to add as much information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should be hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->
BC-9495
<!--
## Changes
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

- set index in room membership on `userGroupId`

## Approval for review

- [x] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

