### PR TITLE
BC-9136 - Copy Videoconference Board Element

### DIFF
--- a/apps/server/src/modules/board/service/internal/board-node-copy.service.ts
+++ b/apps/server/src/modules/board/service/internal/board-node-copy.service.ts
@@ -33,7 +33,7 @@ import {
 	RichTextElement,
 	SubmissionContainerElement,
 	type SubmissionItem,
-	type VideoConferenceElement,
+	VideoConferenceElement,
 } from '../../domain';
 
 export interface CopyContext {
@@ -383,9 +383,15 @@ export class BoardNodeCopyService {
 
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	public copyVideoConferenceElement(original: VideoConferenceElement, context: CopyContext): Promise<CopyStatus> {
+		const copy = new VideoConferenceElement({
+			...original.getProps(),
+			...this.buildSpecificProps([]),
+		});
+
 		const result: CopyStatus = {
+			copyEntity: copy,
 			type: CopyElementType.VIDEO_CONFERENCE_ELEMENT,
-			status: CopyStatusEnum.NOT_DOING,
+			status: CopyStatusEnum.SUCCESS,
 		};
 
 		return Promise.resolve(result);


### PR DESCRIPTION
# Description

Fixes a bug where the videoconference element of a board that was copied was not present in the copy.
<!--
  This is a template to add as much information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should be hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests

BC-9136

<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->

## Changes

<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Approval for review

- [ ] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
