### PR TITLE
Potential fix for code scanning alert no. 378: Sensitive server cookie exposed to the client

### DIFF
--- a/apps/server/src/modules/collaborative-text-editor/api/collaborative-text-editor.controller.ts
+++ b/apps/server/src/modules/collaborative-text-editor/api/collaborative-text-editor.controller.ts
@@ -33,6 +33,7 @@ export class CollaborativeTextEditorController {
 		res.cookie('sessionID', textEditor.sessionId, {
 			expires: textEditor.sessionExpiryDate,
 			secure: true,
+			httpOnly: true,
 			path: textEditor.path,
 		});
 


### PR DESCRIPTION
Potential fix for [https://github.com/hpi-schul-cloud/schulcloud-server/security/code-scanning/378](https://github.com/hpi-schul-cloud/schulcloud-server/security/code-scanning/378)

To fix the issue, the `httpOnly` flag should be added to the cookie options in the `res.cookie` call on line 33. This ensures that the `sessionID` cookie cannot be accessed by client-side scripts, reducing the risk of session hijacking via XSS attacks. The fix involves modifying the options object passed to `res.cookie` to include `httpOnly: true`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
