### PR TITLE
BC-10563: Reset readersCanEdit flag when unpublishing a board

### DIFF
--- a/apps/server/src/modules/board/domain/colum-board.do.ts
+++ b/apps/server/src/modules/board/domain/colum-board.do.ts
@@ -24,6 +24,9 @@ export class ColumnBoard extends BoardNode<ColumnBoardProps> {
 	}
 
 	set isVisible(isVisible: boolean) {
+		if (!isVisible) {
+			this.props.readersCanEdit = false;
+		}
 		this.props.isVisible = isVisible;
 	}
 

--- a/apps/server/src/modules/board/service/board-node.service.spec.ts
+++ b/apps/server/src/modules/board/service/board-node.service.spec.ts
@@ -313,4 +313,31 @@ describe(BoardNodeService.name, () => {
 			});
 		});
 	});
+
+	describe('updateVisibility', () => {
+		describe('when updating the visibility to false', () => {
+			const setup = () => {
+				const node = columnBoardFactory.build({
+					layout: BoardLayout.COLUMNS,
+					readersCanEdit: true,
+					isVisible: true,
+				});
+
+				return {
+					node,
+				};
+			};
+
+			it('should reset the readers can edit flag to false', async () => {
+				const { node } = setup();
+
+				expect(node.isVisible).toBe(true);
+				expect(node.readersCanEdit).toBe(true);
+				await service.updateVisibility(node, false);
+
+				expect(node.isVisible).toBe(false);
+				expect(node.readersCanEdit).toBe(false);
+			});
+		});
+	});
 });

--- a/apps/server/src/modules/board/service/board-node.service.ts
+++ b/apps/server/src/modules/board/service/board-node.service.ts
@@ -48,6 +48,9 @@ export class BoardNodeService {
 		isVisible: T['isVisible']
 	): Promise<void> {
 		node.isVisible = isVisible;
+		if (!isVisible) {
+			node.readersCanEdit = false;
+		}
 		await this.boardNodeRepo.save(node);
 	}
 

--- a/apps/server/src/modules/board/service/board-node.service.ts
+++ b/apps/server/src/modules/board/service/board-node.service.ts
@@ -48,9 +48,6 @@ export class BoardNodeService {
 		isVisible: T['isVisible']
 	): Promise<void> {
 		node.isVisible = isVisible;
-		if (!isVisible) {
-			node.readersCanEdit = false;
-		}
 		await this.boardNodeRepo.save(node);
 	}
 


### PR DESCRIPTION
# Description

When the "readers can edit" flag is set on a published (visible) board and said board is set to draft (invisible) the "readers can edit" flag is reset to false.

## Links to Tickets or other pull requests

https://ticketsystem.dbildungscloud.de/browse/BC-10563

## Approval for review

- [ ] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
