### PR TITLE
BC-10647 libreoffice may not be able to access file via wopi

### DIFF
--- a/src/services/wopi/hooks/index.js
+++ b/src/services/wopi/hooks/index.js
@@ -26,9 +26,9 @@ const wopiAuthentication = (hook) => {
 		throw new Error('access_token is missing!');
 	}
 
-	// remove client specific stuff
-	if (jwt.indexOf('?permission') >= 0) {
-		jwt = jwt.slice(0, jwt.indexOf('?permission'));
+	// for some reason jwt MAY have query params?!
+	if (jwt.includes('?')) {
+		jwt = jwt.slice(0, jwt.indexOf('?'));
 	}
 	hook.params.authentication = {
 		accessToken: jwt,


### PR DESCRIPTION
for some reason the jwt may contain query parameters?! and this bug existed since its initial implementation with a hacky workaround
which is now just replaced with a more robust workaround

# Description

<!--
  This is a template to add as much information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should be hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/BC-10647
<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->

## Changes

<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Approval for review

- [ ] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
