### PR TITLE
BC-11791 - fix url for test from TSP

### DIFF
--- a/ansible/roles/schulcloud-server-init/templates/configmap_file_init.yml.j2
+++ b/ansible/roles/schulcloud-server-init/templates/configmap_file_init.yml.j2
@@ -252,15 +252,15 @@ data:
             "oauthConfig": {
               "clientId": "'$TSP_SYSTEM_OAUTH_CLIENT_ID'",
               "clientSecret": "'$TSP_SYSTEM_OAUTH_CLIENT_SECRET'",
-              "tokenEndpoint": "https://test.schulportal-thueringen.de/auth/realms/TIS/protocol/openid-connect/token",
+              "tokenEndpoint": "https://test3.schulportal-thueringen.de/auth/realms/TIS/protocol/openid-connect/token",
               "grantType": "authorization_code",
               "scope": "openid",
               "responseType": "code",
               "redirectUri": "https://{{ NAMESPACE }}.thr.dbildungscloud.dev/api/v3/sso/oauth",
-              "authEndpoint": "https://test.schulportal-thueringen.de/auth/realms/TIS/protocol/openid-connect/auth",
+              "authEndpoint": "https://test3.schulportal-thueringen.de/auth/realms/TIS/protocol/openid-connect/auth",
               "provider": "tsp",
-              "jwksEndpoint": "https://test.schulportal-thueringen.de/auth/realms/TIS/protocol/openid-connect/certs",
-              "issuer": "https://test.schulportal-thueringen.de/auth/realms/TIS"
+              "jwksEndpoint": "https://test3.schulportal-thueringen.de/auth/realms/TIS/protocol/openid-connect/certs",
+              "issuer": "https://test3.schulportal-thueringen.de/auth/realms/TIS"
             }
           }
       );'

--- a/apps/server/src/infra/tsp-client/README.md
+++ b/apps/server/src/infra/tsp-client/README.md
@@ -30,7 +30,7 @@ export class MyNewService {
 ## How the code generation works
 
 > IMPORTANT: Currently we are using the `openapi.json` and not the spec from 
-> https://test.schulportal-thueringen.de/tip-ms/api/swagger.json, because we have to patch the security schemas
+> https://test3.schulportal-thueringen.de/tip-ms/api/swagger.json, because we have to patch the security schemas
 > manually into to the specification so the generator can generate them correctly. The provided
 > specification does not contain all necessary definitions. Only the `Export` endpoints are
 > decorated with the security definitions.

--- a/apps/server/src/infra/tsp-client/tsp-client-factory.integration.spec.ts
+++ b/apps/server/src/infra/tsp-client/tsp-client-factory.integration.spec.ts
@@ -16,7 +16,7 @@ describe.skip('TspClientFactory Integration', () => {
 		})
 			.overrideProvider(TSP_CLIENT_CONFIG_TOKEN)
 			.useValue({
-				baseUrl: 'https://test.schulportal-thueringen.de/tip-ms/api',
+				baseUrl: 'https://test3.schulportal-thueringen.de/tip-ms/api',
 				tokenLifetimeMs: 30000,
 			})
 			.compile();


### PR DESCRIPTION
# Description
TSP has change the URL for there test system so we must addept 

## Links to Tickets or other pull requests
- https://ticketsystem.dbildungscloud.de/browse/BC-11791
- hpi-schul-cloud/dof_app_deploy#1406

## Changes

<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Approval for review

- [ ] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
