### PR TITLE
BC-11880 - Missing auth on ldap-config endpoint

### DIFF
--- a/src/services/ldap-config/hooks/index.js
+++ b/src/services/ldap-config/hooks/index.js
@@ -1,7 +1,7 @@
 const { authenticate } = require('@feathersjs/authentication');
 const { iff, isProvider, disallow } = require('feathers-hooks-common');
 
-const { populateCurrentSchool } = require('../../../hooks');
+const { populateCurrentSchool, hasPermission } = require('../../../hooks');
 const fillDefaultValues = require('./fillDefaultValues');
 const restrictToSchoolSystems = require('../../ldap/hooks/restrictToSchoolSystems');
 
@@ -12,14 +12,14 @@ module.exports = {
 		create: [
 			// only allow external calls (the service needs a user)
 			iff(!isProvider('external'), disallow()),
-			globalHooks.hasPermission('SYSTEM_EDIT'),
+			hasPermission('SYSTEM_EDIT'),
 			populateCurrentSchool,
 			fillDefaultValues,
 		],
 		patch: [
 			// only allow external calls (the service needs a user)
 			iff(!isProvider('external'), disallow()),
-			globalHooks.hasPermission('SYSTEM_EDIT'),
+			hasPermission('SYSTEM_EDIT'),
 			populateCurrentSchool,
 			restrictToSchoolSystems,
 			fillDefaultValues,

--- a/src/services/ldap-config/hooks/index.js
+++ b/src/services/ldap-config/hooks/index.js
@@ -5,6 +5,33 @@ const { populateCurrentSchool } = require('../../../hooks');
 const fillDefaultValues = require('./fillDefaultValues');
 const restrictToSchoolSystems = require('../../ldap/hooks/restrictToSchoolSystems');
 
+const hasEditPermission = async (context) => {
+	const { userId } = context.params.account;
+	const { roles } = await context.app.service('users').get(userId, { query: { $populate: 'roles' } });
+	const isAdministrator = roles.find((r) => r.name === 'administrator');
+
+	if (!isAdministrator) {
+		throw new Error('You do not have permission to change the LDAP configuration');
+	}
+};
+
+const hasCreatePermission = async (context) => {
+	hasEditPermission(context);
+};
+
+const hasPatchPermission = async (context) => {
+	hasEditPermission(context);
+};
+
+/* TODO
+	globalHooks.hasPermission auf ...
+	SCHOOL_EDIT: 'SCHOOL_EDIT', // der wird zumindest in ldap/hooks benutzt
+	SCHOOL_PERMISSION_CHANGE: 'SCHOOL_PERMISSION_CHANGE',
+	SCHOOL_SYSTEM_EDIT: 'SCHOOL_SYSTEM_EDIT',
+	SCHOOL_TOOL_ADMIN: 'SCHOOL_TOOL_ADMIN',
+	??
+	*/
+
 module.exports = {
 	before: {
 		all: [authenticate('jwt')],
@@ -12,12 +39,16 @@ module.exports = {
 		create: [
 			// only allow external calls (the service needs a user)
 			iff(!isProvider('external'), disallow()),
+			globalHooks.hasPermission('SCHOOL_EDIT'),
+			hasCreatePermission,
 			populateCurrentSchool,
 			fillDefaultValues,
 		],
 		patch: [
 			// only allow external calls (the service needs a user)
 			iff(!isProvider('external'), disallow()),
+			globalHooks.hasPermission('SCHOOL_EDIT'),
+			hasPatchPermission,
 			populateCurrentSchool,
 			restrictToSchoolSystems,
 			fillDefaultValues,

--- a/src/services/ldap-config/hooks/index.js
+++ b/src/services/ldap-config/hooks/index.js
@@ -5,33 +5,6 @@ const { populateCurrentSchool } = require('../../../hooks');
 const fillDefaultValues = require('./fillDefaultValues');
 const restrictToSchoolSystems = require('../../ldap/hooks/restrictToSchoolSystems');
 
-const hasEditPermission = async (context) => {
-	const { userId } = context.params.account;
-	const { roles } = await context.app.service('users').get(userId, { query: { $populate: 'roles' } });
-	const isAdministrator = roles.find((r) => r.name === 'administrator');
-
-	if (!isAdministrator) {
-		throw new Error('You do not have permission to change the LDAP configuration');
-	}
-};
-
-const hasCreatePermission = async (context) => {
-	hasEditPermission(context);
-};
-
-const hasPatchPermission = async (context) => {
-	hasEditPermission(context);
-};
-
-/* TODO
-	globalHooks.hasPermission auf ...
-	SCHOOL_EDIT: 'SCHOOL_EDIT', // der wird zumindest in ldap/hooks benutzt
-	SCHOOL_PERMISSION_CHANGE: 'SCHOOL_PERMISSION_CHANGE',
-	SCHOOL_SYSTEM_EDIT: 'SCHOOL_SYSTEM_EDIT',
-	SCHOOL_TOOL_ADMIN: 'SCHOOL_TOOL_ADMIN',
-	??
-	*/
-
 module.exports = {
 	before: {
 		all: [authenticate('jwt')],
@@ -39,16 +12,14 @@ module.exports = {
 		create: [
 			// only allow external calls (the service needs a user)
 			iff(!isProvider('external'), disallow()),
-			globalHooks.hasPermission('SCHOOL_EDIT'),
-			hasCreatePermission,
+			globalHooks.hasPermission('SYSTEM_EDIT'),
 			populateCurrentSchool,
 			fillDefaultValues,
 		],
 		patch: [
 			// only allow external calls (the service needs a user)
 			iff(!isProvider('external'), disallow()),
-			globalHooks.hasPermission('SCHOOL_EDIT'),
-			hasPatchPermission,
+			globalHooks.hasPermission('SYSTEM_EDIT'),
 			populateCurrentSchool,
 			restrictToSchoolSystems,
 			fillDefaultValues,


### PR DESCRIPTION
# Description

Add checks for `SYSTEM_EDIT` permission (which only admins have, therefore no check on user role) on the ldap-config endpoint.

<!--
  This is a template to add as much information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should be hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->
<!-- related-prs-and-tickets-start -->
<!-- related-prs-and-tickets-end -->

## Changes

<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Approval for review

- [ ] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
