### PR TITLE
BC-3187 - News: Only 9 news visible, despite pagination

### DIFF
--- a/apps/server/src/modules/news/api/news.controller.ts
+++ b/apps/server/src/modules/news/api/news.controller.ts
@@ -3,12 +3,12 @@ import { Body, Controller, Delete, Get, Param, Patch, Post, Query } from '@nestj
 import { ApiTags } from '@nestjs/swagger';
 import { PaginationParams } from '@shared/controller/dto';
 import {
-    CreateNewsParams,
-    FilterNewsParams,
-    NewsListResponse,
-    NewsResponse,
-    NewsUrlParams,
-    UpdateNewsParams,
+	CreateNewsParams,
+	FilterNewsParams,
+	NewsListResponse,
+	NewsResponse,
+	NewsUrlParams,
+	UpdateNewsParams,
 } from './dto';
 import { NewsMapper } from './mapper';
 import { NewsUc } from './news.uc';

--- a/apps/server/src/modules/news/api/news.controller.ts
+++ b/apps/server/src/modules/news/api/news.controller.ts
@@ -3,12 +3,12 @@ import { Body, Controller, Delete, Get, Param, Patch, Post, Query } from '@nestj
 import { ApiTags } from '@nestjs/swagger';
 import { PaginationParams } from '@shared/controller/dto';
 import {
-	CreateNewsParams,
-	FilterNewsParams,
-	NewsListResponse,
-	NewsResponse,
-	NewsUrlParams,
-	UpdateNewsParams,
+    CreateNewsParams,
+    FilterNewsParams,
+    NewsListResponse,
+    NewsResponse,
+    NewsUrlParams,
+    UpdateNewsParams,
 } from './dto';
 import { NewsMapper } from './mapper';
 import { NewsUc } from './news.uc';
@@ -51,7 +51,7 @@ export class NewsController {
 			{ pagination }
 		);
 		const dtoList = newsList.map((news) => NewsMapper.mapToResponse(news));
-		const response = new NewsListResponse(dtoList, count);
+		const response = new NewsListResponse(dtoList, count, pagination.skip, pagination.limit);
 		return response;
 	}
 

--- a/apps/server/src/modules/news/api/test/news.api.spec.ts
+++ b/apps/server/src/modules/news/api/test/news.api.spec.ts
@@ -140,6 +140,27 @@ describe('News Controller (API)', () => {
 				expect(data[0].id).toBe(expected.data[0]._id.toString());
 			});
 
+			it('should return the second page and pagination metadata', async () => {
+				const { loggedInClient, studentUser } = await setup();
+				await createCourseTarget(courseTargetId, studentUser);
+				const newsList = Array.from({ length: 11 }, () =>
+					newTestNews(NewsTargetModel.Course, courseTargetId, studentUser)
+				);
+				await em.persist(newsList).flush();
+
+				const firstPageResponse = await loggedInClient.get('?skip=0&limit=10').expect(200);
+				const secondPageResponse = await loggedInClient.get('?skip=10&limit=10').expect(200);
+				const firstPage = firstPageResponse.body as NewsListResponse;
+				const { data, total, skip, limit } = secondPageResponse.body as NewsListResponse;
+
+				expect(firstPage.data).toHaveLength(10);
+				expect(data).toHaveLength(1);
+				expect(firstPage.data.map((news) => news.id)).not.toContain(data[0].id);
+				expect(total).toBe(11);
+				expect(skip).toBe(10);
+				expect(limit).toBe(10);
+			});
+
 			it('should get for /news with unpublished params only unpublished news', async () => {
 				const { loggedInClient, studentUser } = await setup();
 				await createCourseTarget(unpublishedCourseTargetId, studentUser);

--- a/apps/server/src/modules/news/repo/news.repo.integration.spec.ts
+++ b/apps/server/src/modules/news/repo/news.repo.integration.spec.ts
@@ -1,6 +1,7 @@
 import { NotFoundError } from '@mikro-orm/core';
 import { EntityManager, ObjectId } from '@mikro-orm/mongodb';
 import { CourseEntity, CourseGroupEntity } from '@modules/course/repo';
+import { courseEntityFactory } from '@modules/course/testing';
 import {
 	courseNewsFactory,
 	courseUnpublishedNewsFactory,
@@ -9,7 +10,9 @@ import {
 	teamNewsFactory,
 	teamUnpublishedNewsFactory,
 } from '@modules/news/testing';
+import { schoolEntityFactory } from '@modules/school/testing';
 import { TeamEntity } from '@modules/team/repo';
+import { teamFactory } from '@modules/team/testing/team.factory';
 import { userFactory } from '@modules/user/testing';
 import { Test, type TestingModule } from '@nestjs/testing';
 import { SortOrder } from '@shared/domain/interface';
@@ -18,9 +21,6 @@ import { MongoMemoryDatabaseModule } from '@testing/database';
 import { NewsTargetModel } from '../domain';
 import { CourseNews, News, SchoolNews, TeamNews } from './news.entity';
 import { NewsRepo } from './news.repo';
-import { courseEntityFactory } from '@modules/course/testing';
-import { teamFactory } from '@modules/team/testing/team.factory';
-import { schoolEntityFactory } from '@modules/school/testing';
 
 describe('NewsRepo', () => {
 	let repo: NewsRepo;

--- a/apps/server/src/modules/news/repo/news.repo.ts
+++ b/apps/server/src/modules/news/repo/news.repo.ts
@@ -1,7 +1,7 @@
 import { EntityName, FilterQuery, QueryOrderMap } from '@mikro-orm/core';
 import { ObjectId } from '@mikro-orm/mongodb';
 import { Injectable } from '@nestjs/common';
-import { IFindOptions } from '@shared/domain/interface';
+import { IFindOptions, SortOrder } from '@shared/domain/interface';
 import { Counted, EntityId } from '@shared/domain/types';
 import { BaseRepo } from '@shared/repo/base.repo';
 import { getFieldName } from '@shared/repo/utils/repo-helper';
@@ -87,9 +87,11 @@ export class NewsRepo extends BaseRepo<News> {
 	/** resolves a news documents list with some elements (school, target, and updator/creator) populated already */
 	private async findNewsAndCount(query: FilterQuery<News>, options?: IFindOptions<News>): Promise<Counted<News[]>> {
 		const { pagination, order } = options || {};
+		const orderBy = { ...order, _id: order?._id ?? SortOrder.desc } as QueryOrderMap<News>;
 		const [newsEntities, count] = await this._em.findAndCount(News, query, {
-			...pagination,
-			orderBy: order as QueryOrderMap<News>,
+			offset: pagination?.skip,
+			limit: pagination?.limit,
+			orderBy,
 		});
 		// populate target for all inheritances of news which not works when the list contains different types
 		const schoolNews = newsEntities.filter((news) => news instanceof SchoolNews);

--- a/apps/server/src/modules/news/repo/news.repo.ts
+++ b/apps/server/src/modules/news/repo/news.repo.ts
@@ -87,7 +87,7 @@ export class NewsRepo extends BaseRepo<News> {
 	/** resolves a news documents list with some elements (school, target, and updator/creator) populated already */
 	private async findNewsAndCount(query: FilterQuery<News>, options?: IFindOptions<News>): Promise<Counted<News[]>> {
 		const { pagination, order } = options || {};
-		const orderBy = { ...order, _id: order?._id ?? SortOrder.desc } as QueryOrderMap<News>;
+		const orderBy = order ? ({ ...order, _id: order._id ?? SortOrder.desc } as QueryOrderMap<News>) : undefined;
 		const [newsEntities, count] = await this._em.findAndCount(News, query, {
 			offset: pagination?.skip,
 			limit: pagination?.limit,


### PR DESCRIPTION
# Description
News: Only 9 news visible, despite pagination
<!--
  This is a template to add as much information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should be hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
BC-3187
https://github.com/hpi-schul-cloud/nuxt-client/pull/4326

<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->
<!-- related-prs-and-tickets-start -->
<!-- related-prs-and-tickets-end -->

## Changes
- adjust ORM translation with correct param name
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Approval for review

- [ ] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
