### PR TITLE
BC-2166 Delete course files and cascade homework cleanup on course/lesson removal

### DIFF
--- a/src/services/homework/removeDependentHomeworks.js
+++ b/src/services/homework/removeDependentHomeworks.js
@@ -1,0 +1,29 @@
+const { Types } = require('mongoose');
+const { homeworkModel, submissionModel } = require('./model');
+
+const toObjectId = (id) => new Types.ObjectId(id.toString());
+
+const removeHomeworks = async (query) => {
+	const homeworks = await homeworkModel.find(query).select({ _id: 1 }).lean().exec();
+	const homeworkIds = homeworks.map((homework) => homework._id);
+
+	if (homeworkIds.length === 0) {
+		return;
+	}
+
+	await submissionModel.deleteMany({ homeworkId: { $in: homeworkIds } }).exec();
+	await homeworkModel.deleteMany({ _id: { $in: homeworkIds } }).exec();
+};
+
+const removeHomeworksByCourseId = async (courseId) => {
+	await removeHomeworks({ courseId: toObjectId(courseId) });
+};
+
+const removeHomeworksByLessonId = async (lessonId) => {
+	await removeHomeworks({ lessonId: toObjectId(lessonId) });
+};
+
+module.exports = {
+	removeHomeworksByCourseId,
+	removeHomeworksByLessonId,
+};

--- a/src/services/lesson/hooks/index.js
+++ b/src/services/lesson/hooks/index.js
@@ -5,6 +5,7 @@ const { nanoid } = require('nanoid');
 const { iff, isProvider } = require('feathers-hooks-common');
 const { NotFound, BadRequest } = require('../../../errors');
 const { equal } = require('../../../helper/compare').ObjectId;
+const { removeHomeworksByLessonId } = require('../../homework/removeDependentHomeworks');
 const {
 	injectUserId,
 	hasPermission,
@@ -197,5 +198,10 @@ exports.after = {
 	create: [addShareTokenIfCourseShareable],
 	update: [],
 	patch: [],
-	remove: [],
+	remove: [
+		async (context) => {
+			await removeHomeworksByLessonId(context.id || context.result._id);
+			return context;
+		},
+	],
 };

--- a/src/services/user-group/services/courses.js
+++ b/src/services/user-group/services/courses.js
@@ -17,6 +17,9 @@ const {
 const {
 	modelServices: { prepareInternalParams },
 } = require('../../../utils');
+const { removeHomeworksByCourseId } = require('../../homework/removeDependentHomeworks');
+const { filesRepo } = require('../../fileStorage/repo');
+const { FileModel } = require('../../fileStorage/model');
 const { removeLessonsByCourseId } = require('./removeDependentLessons');
 
 const restrictToCurrentSchoolIfNotLocal = ifNotLocal(restrictToCurrentSchool);
@@ -64,8 +67,18 @@ class Courses {
 
 	async remove(id, params) {
 		const internalParams = prepareInternalParams(params);
+		const courseFiles = await FileModel.find({
+			owner: id,
+			refOwnerModel: 'course',
+			deleted: { $ne: true },
+		})
+			.select({ _id: 1 })
+			.lean()
+			.exec();
 
+		await removeHomeworksByCourseId(id);
 		await removeLessonsByCourseId(id);
+		await Promise.all(courseFiles.map((file) => filesRepo.removeFileById(file._id)));
 		this.app.service('/calendar/courses').remove(id, internalParams);
 		return this.app.service('courseModel').remove(id, internalParams);
 	}

--- a/test/services/lessons/index.test.js
+++ b/test/services/lessons/index.test.js
@@ -3,6 +3,7 @@ const { expect } = require('chai');
 const appPromise = require('../../../src/app');
 const { setupNestServices, closeNestServices } = require('../../utils/setup.nest.services');
 const testObjects = require('../helpers/testObjects')(appPromise());
+const { homeworkModel, submissionModel } = require('../../../src/services/homework/model');
 
 const testLesson = {
 	name: 'testLesson',
@@ -139,6 +140,49 @@ describe('lessons service', () => {
 			const result = await app.service('lessons').create(data, params);
 			expect(result).to.haveOwnProperty('_id');
 			expect(result.name).to.equal('Here we go...');
+		});
+
+		it('teacher can REMOVE lesson and its dependent homework', async () => {
+			const { _id: schoolId } = await testObjects.createTestSchool({});
+			const teacher = await testObjects.createTestUser({ roles: ['teacher'], schoolId });
+			const student = await testObjects.createTestUser({ roles: ['student'], schoolId });
+			const course = await testObjects.createTestCourse({
+				schoolId,
+				teacherIds: [teacher._id],
+				userIds: [student._id],
+			});
+			const otherLesson = await testObjects.createTestLesson({ courseId: course._id });
+			const lesson = await testObjects.createTestLesson({ courseId: course._id });
+			const homework = await testObjects.createTestHomework({
+				schoolId,
+				teacherId: teacher._id,
+				courseId: course._id,
+				lessonId: lesson._id,
+			});
+			const unrelatedHomework = await testObjects.createTestHomework({
+				schoolId,
+				teacherId: teacher._id,
+				courseId: course._id,
+				lessonId: otherLesson._id,
+			});
+			const submission = await testObjects.createTestSubmission({
+				schoolId,
+				studentId: student._id,
+				homeworkId: homework._id,
+			});
+			const unrelatedSubmission = await testObjects.createTestSubmission({
+				schoolId,
+				studentId: student._id,
+				homeworkId: unrelatedHomework._id,
+			});
+
+			const params = await testObjects.generateRequestParamsFromUser(teacher);
+			await app.service('lessons').remove(lesson._id, params);
+
+			expect(await homeworkModel.findById(homework._id).lean().exec()).to.be.null;
+			expect(await submissionModel.findById(submission._id).lean().exec()).to.be.null;
+			expect(await homeworkModel.findById(unrelatedHomework._id).lean().exec()).to.not.be.null;
+			expect(await submissionModel.findById(unrelatedSubmission._id).lean().exec()).to.not.be.null;
 		});
 	});
 

--- a/test/services/user-group/services/courses.test.js
+++ b/test/services/user-group/services/courses.test.js
@@ -3,6 +3,8 @@ const appPromise = require('../../../../src/app');
 const { setupNestServices, closeNestServices } = require('../../../utils/setup.nest.services');
 const testObjects = require('../../helpers/testObjects')(appPromise());
 const { courseModel } = require('../../../../src/services/user-group/model');
+const { FileModel } = require('../../../../src/services/fileStorage/model');
+const { homeworkModel, submissionModel } = require('../../../../src/services/homework/model');
 const { LessonModel } = require('../../../../src/services/lesson/model');
 
 describe('course service', () => {
@@ -111,6 +113,100 @@ describe('course service', () => {
 		expect(await LessonModel.findById(unrelatedCourseLesson._id).lean().exec()).to.not.be.null;
 		expect(await LessonModel.findById(unrelatedCourseGroupLesson._id).lean().exec()).to.not.be.null;
 		expect(await app.service('courseGroupModel').get(otherCourseGroup._id)).to.not.be.null;
+	});
+
+	it('REMOVE a course and its dependent files', async () => {
+		const { _id: schoolId } = await testObjects.createTestSchool({});
+		const teacher = await testObjects.createTestUser({ roles: ['teacher'], schoolId });
+		const course = await testObjects.createTestCourse({ schoolId, teacherIds: [teacher._id] });
+		const otherCourse = await testObjects.createTestCourse({ schoolId, teacherIds: [teacher._id] });
+		const courseFile = await FileModel.create({
+			isDirectory: false,
+			name: 'course-file.txt',
+			type: 'text/plain',
+			size: 12,
+			storageFileName: 'course-file.txt',
+			bucket: 'bucket-test',
+			storageProviderId: teacher._id,
+			owner: course._id,
+			refOwnerModel: 'course',
+			creator: teacher._id,
+			permissions: [{ refId: teacher._id, refPermModel: 'user', read: true, write: true, create: true, delete: true }],
+		});
+		const unrelatedCourseFile = await FileModel.create({
+			isDirectory: false,
+			name: 'other-course-file.txt',
+			type: 'text/plain',
+			size: 12,
+			storageFileName: 'other-course-file.txt',
+			bucket: 'bucket-test',
+			storageProviderId: teacher._id,
+			owner: otherCourse._id,
+			refOwnerModel: 'course',
+			creator: teacher._id,
+			permissions: [{ refId: teacher._id, refPermModel: 'user', read: true, write: true, create: true, delete: true }],
+		});
+
+		const params = await testObjects.generateRequestParamsFromUser(teacher);
+		await app.service('courses').remove(course._id, params);
+
+		expect(await FileModel.findById(courseFile._id).lean().exec()).to.be.null;
+		expect((await FileModel.findOneWithDeleted({ _id: courseFile._id }).lean().exec()).deleted).to.be.true;
+		expect(await FileModel.findById(unrelatedCourseFile._id).lean().exec()).to.not.be.null;
+	});
+
+	it('REMOVE a course and its dependent homework', async () => {
+		const { _id: schoolId } = await testObjects.createTestSchool({});
+		const teacher = await testObjects.createTestUser({ roles: ['teacher'], schoolId });
+		const student = await testObjects.createTestUser({ roles: ['student'], schoolId });
+		const course = await testObjects.createTestCourse({ schoolId, teacherIds: [teacher._id], userIds: [student._id] });
+		const otherCourse = await testObjects.createTestCourse({
+			schoolId,
+			teacherIds: [teacher._id],
+			userIds: [student._id],
+		});
+		const homework = await testObjects.createTestHomework({
+			schoolId,
+			teacherId: teacher._id,
+			courseId: course._id,
+		});
+		const lesson = await testObjects.createTestLesson({ courseId: course._id });
+		const lessonHomework = await testObjects.createTestHomework({
+			schoolId,
+			teacherId: teacher._id,
+			courseId: course._id,
+			lessonId: lesson._id,
+		});
+		const unrelatedHomework = await testObjects.createTestHomework({
+			schoolId,
+			teacherId: teacher._id,
+			courseId: otherCourse._id,
+		});
+		const homeworkSubmission = await testObjects.createTestSubmission({
+			schoolId,
+			studentId: student._id,
+			homeworkId: homework._id,
+		});
+		const lessonHomeworkSubmission = await testObjects.createTestSubmission({
+			schoolId,
+			studentId: student._id,
+			homeworkId: lessonHomework._id,
+		});
+		const unrelatedSubmission = await testObjects.createTestSubmission({
+			schoolId,
+			studentId: student._id,
+			homeworkId: unrelatedHomework._id,
+		});
+
+		const params = await testObjects.generateRequestParamsFromUser(teacher);
+		await app.service('courses').remove(course._id, params);
+
+		expect(await homeworkModel.findById(homework._id).lean().exec()).to.be.null;
+		expect(await homeworkModel.findById(lessonHomework._id).lean().exec()).to.be.null;
+		expect(await submissionModel.findById(homeworkSubmission._id).lean().exec()).to.be.null;
+		expect(await submissionModel.findById(lessonHomeworkSubmission._id).lean().exec()).to.be.null;
+		expect(await homeworkModel.findById(unrelatedHomework._id).lean().exec()).to.not.be.null;
+		expect(await submissionModel.findById(unrelatedSubmission._id).lean().exec()).to.not.be.null;
 	});
 
 	describe('security features', () => {


### PR DESCRIPTION


- delete course-owned fileStorage records when a course is removed
- delete homework and related submissions when a course is removed
- delete lesson-linked homework and related submissions when a lesson is removed


# Description

<!--
  This is a template to add as much information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should be hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/BC-2166
https://ticketsystem.dbildungscloud.de/browse/BC-2411
<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->
<!-- related-prs-and-tickets-start -->
<!-- related-prs-and-tickets-end -->

## Changes

<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Approval for review

- [ ] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
