### PR TITLE
BC-12128 - blocking contact form

### DIFF
--- a/apps/server/src/modules/helpdesk/api/test/helpdesk-problem.api.spec.ts
+++ b/apps/server/src/modules/helpdesk/api/test/helpdesk-problem.api.spec.ts
@@ -119,6 +119,31 @@ describe('Helpdesk Controller (API)', () => {
 			});
 		});
 
+		describe('when logged in user email is invalid', () => {
+			const setup = async (email: string) => {
+				const body = HelpdeskProblemCreateParamsFactory.create();
+				const { studentAccount, studentUser } = UserAndAccountTestFactory.buildStudent({ email });
+
+				await em.persist([studentAccount, studentUser]).flush();
+
+				const loggedInClient = await new TestApiClientBuilder(app, baseRouteName).build(studentAccount);
+
+				return { loggedInClient, body };
+			};
+
+			it.each([
+				['obviously malformed', 'invalid-email-address'],
+				['passing the frontend regex but failing class-validator', 'test@example'],
+				['passing the frontend regex but containing a copy-pasted look-alike dot', 'joerg.winterwald@nibis｡de'],
+			])('should return 500 for %s email', async (_scenario, email) => {
+				const { loggedInClient, body } = await setup(email);
+
+				const response = await loggedInClient.post('problem', body);
+
+				expect(response.status).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+			});
+		});
+
 		describe('when problemArea is missing', () => {
 			const setup = async () => {
 				const body = HelpdeskProblemCreateParamsFactory.create({ problemArea: undefined as unknown as string[] });

--- a/apps/server/src/modules/helpdesk/api/test/helpdesk-problem.api.spec.ts
+++ b/apps/server/src/modules/helpdesk/api/test/helpdesk-problem.api.spec.ts
@@ -119,10 +119,10 @@ describe('Helpdesk Controller (API)', () => {
 			});
 		});
 
-		describe('when logged in user email is invalid', () => {
-			const setup = async (email: string) => {
-				const body = HelpdeskProblemCreateParamsFactory.create();
-				const { studentAccount, studentUser } = UserAndAccountTestFactory.buildStudent({ email });
+		describe('when replyEmail is invalid', () => {
+			const setup = async (replyEmail: string) => {
+				const body = HelpdeskProblemCreateParamsFactory.create({ replyEmail });
+				const { studentAccount, studentUser } = UserAndAccountTestFactory.buildStudent();
 
 				await em.persist([studentAccount, studentUser]).flush();
 
@@ -140,7 +140,13 @@ describe('Helpdesk Controller (API)', () => {
 
 				const response = await loggedInClient.post('problem', body);
 
-				expect(response.status).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+				expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+				expect(response.body).toEqual(
+					expect.objectContaining({
+						message: expect.stringContaining('API validation failed'),
+						validationErrors: expect.anything(),
+					})
+				);
 			});
 		});
 

--- a/apps/server/src/modules/helpdesk/domain/service/helpdesk.service.spec.ts
+++ b/apps/server/src/modules/helpdesk/domain/service/helpdesk.service.spec.ts
@@ -204,6 +204,44 @@ describe('HelpdeskService', () => {
 				});
 			});
 		});
+
+		describe('when user creating the problem is a supporter with an empty email adress in his user account', () => {
+			const setup = () => {
+				const problem = helpdeskProblemPropsFactory.create();
+				const userContext = userContextPropsFactory.create({ userEmail: '' });
+				const plainTextContent = TextFormatter.createProblemText(problem, userContext);
+
+				return { problem, userContext, plainTextContent };
+			};
+
+			it('should not block the sending and call emailService.send with correct parameters', async () => {
+				const { problem, userContext, plainTextContent } = setup();
+
+				await service.createProblem(problem, userContext);
+
+				expect(mailService.send).toHaveBeenCalledWith({
+					recipients: [config.problemEmailAddress],
+					mail: {
+						subject: problem.subject,
+						plainTextContent,
+						attachments: undefined,
+					},
+					replyTo: [problem.replyEmail],
+				});
+				expect(plainTextContent).toContain(userContext.userId);
+				expect(plainTextContent).toContain(userContext.userName);
+				expect(plainTextContent).toContain(userContext.schoolId);
+				expect(plainTextContent).toContain(userContext.schoolName);
+			});
+
+			it('should not call logger.debug', async () => {
+				const { problem, userContext } = setup();
+
+				await service.createProblem(problem, userContext);
+
+				expect(logger.debug).not.toHaveBeenCalled();
+			});
+		});
 	});
 
 	describe('createWish', () => {

--- a/apps/server/src/modules/helpdesk/domain/vo/user-context.vo.spec.ts
+++ b/apps/server/src/modules/helpdesk/domain/vo/user-context.vo.spec.ts
@@ -173,4 +173,19 @@ describe('UserContext', () => {
 			expect(() => new UserContext(props as unknown as UserContextProps)).toThrow();
 		});
 	});
+
+	describe('when user does not have an email', () => {
+		it('should allow userEmail to be an empty string', () => {
+			const props = {
+				userId: new ObjectId().toHexString(),
+				userName: 'Test User',
+				userEmail: '',
+				userRoles: ['admin'],
+				schoolId: new ObjectId().toHexString(),
+				schoolName: 'Test School',
+				instanceName: 'Test Instance',
+			};
+			expect(() => new UserContext(props as UserContextProps)).not.toThrow();
+		});
+	});
 });

--- a/apps/server/src/modules/helpdesk/domain/vo/user-context.vo.ts
+++ b/apps/server/src/modules/helpdesk/domain/vo/user-context.vo.ts
@@ -1,5 +1,5 @@
 import { ValueObject } from '@shared/domain/value-object.decorator';
-import { IsArray, IsEmail, IsMongoId, IsString } from 'class-validator';
+import { IsArray, IsMongoId, IsString } from 'class-validator';
 import { UserContextProps } from '..';
 
 @ValueObject()
@@ -10,7 +10,7 @@ export class UserContext implements UserContextProps {
 	@IsString()
 	public readonly userName: string;
 
-	@IsEmail()
+	@IsString()
 	public readonly userEmail: string;
 
 	@IsArray()


### PR DESCRIPTION
# Description
Entering invalid data in the contact form's e-mail-address field could result in passing frontend-validation, but failing at backend-validation. 

## Links to Tickets or other pull requests
BC-12128
https://github.com/hpi-schul-cloud/schulcloud-client/pull/3878

## Changes
- The validation of email-addresses was slightly improved in frontend-code at the only thing that differed from recommended pattern.
- only added test-cases to backend e-mail-adress-validation to illustrate the former problem

## Approval for review

- [x] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
