### PR TITLE
BC-12160 - adapt etherpad client adapter to v3.3.3

### DIFF
--- a/apps/server/src/modules/collaborative-text-editor/api/collaborative-text-editor.controller.ts
+++ b/apps/server/src/modules/collaborative-text-editor/api/collaborative-text-editor.controller.ts
@@ -30,7 +30,10 @@ export class CollaborativeTextEditorController {
 			getCollaborativeTextEditorForParentParams
 		);
 
-		res.cookie('sessionID', textEditor.sessionId, {
+		const sessionIds = await this.collaborativeTextEditorUc.getSessionIdsOfUser(currentUser.userId);
+		const sessionIdList = sessionIds.join(',');
+
+		res.cookie('sessionID', sessionIdList, {
 			expires: textEditor.sessionExpiryDate,
 			secure: true,
 			path: '/etherpad/', //textEditor.path,

--- a/apps/server/src/modules/collaborative-text-editor/api/collaborative-text-editor.controller.ts
+++ b/apps/server/src/modules/collaborative-text-editor/api/collaborative-text-editor.controller.ts
@@ -33,7 +33,9 @@ export class CollaborativeTextEditorController {
 		res.cookie('sessionID', textEditor.sessionId, {
 			expires: textEditor.sessionExpiryDate,
 			secure: true,
-			path: textEditor.path,
+			path: '/etherpad/', //textEditor.path,
+			sameSite: 'lax',
+			httpOnly: true,
 		});
 
 		const dto = CollaborativeTextEditorMapper.mapCollaborativeTextEditorToResponse(textEditor);

--- a/apps/server/src/modules/collaborative-text-editor/api/collaborative-text-editor.uc.ts
+++ b/apps/server/src/modules/collaborative-text-editor/api/collaborative-text-editor.uc.ts
@@ -37,6 +37,14 @@ export class CollaborativeTextEditorUc {
 		return textEditor;
 	}
 
+	public async getSessionIdsOfUser(userId: EntityId): Promise<string[]> {
+		const user = await this.authorizationService.getUserWithPermissions(userId);
+
+		const sessionIds = await this.collaborativeTextEditorService.getSessionIdsOfAuthor(user.id);
+
+		return sessionIds;
+	}
+
 	public async deleteSessionsByUser(userId: EntityId): Promise<void> {
 		const user = await this.authorizationService.getUserWithPermissions(userId);
 

--- a/apps/server/src/modules/collaborative-text-editor/api/tests/get-collaborative-text-editor.api.spec.ts
+++ b/apps/server/src/modules/collaborative-text-editor/api/tests/get-collaborative-text-editor.api.spec.ts
@@ -137,10 +137,10 @@ describe('Collaborative Text Editor Controller (API)', () => {
 
 					const editorId = 'editorId';
 					etherpadClientAdapter.getOrCreateEtherpadId.mockResolvedValueOnce(editorId);
-					const otherSessionIds = [];
-					etherpadClientAdapter.listSessionIdsOfAuthor.mockResolvedValueOnce(otherSessionIds);
 					const sessionId = 'sessionId';
 					etherpadClientAdapter.getOrCreateSessionId.mockResolvedValueOnce(sessionId);
+					const otherSessionIds = [sessionId];
+					etherpadClientAdapter.listSessionIdsOfAuthor.mockResolvedValueOnce(otherSessionIds);
 
 					const basePath = 'http://localhost:9001/p';
 					const expectedPath = `${basePath}/${editorId}`;
@@ -160,14 +160,8 @@ describe('Collaborative Text Editor Controller (API)', () => {
 				};
 
 				it('should return response and set cookie', async () => {
-					const {
-						loggedInClient,
-						collaborativeTextEditorElement,
-						expectedPath,
-						sessionId,
-						sessionCookieExpiryDate,
-						editorId,
-					} = await setup();
+					const { loggedInClient, collaborativeTextEditorElement, expectedPath, sessionId, sessionCookieExpiryDate } =
+						await setup();
 
 					const response = await loggedInClient.get(`content-element/${collaborativeTextEditorElement.id}`);
 
@@ -176,7 +170,7 @@ describe('Collaborative Text Editor Controller (API)', () => {
 					expect(response.body['url']).toEqual(expectedPath);
 
 					expect(response.headers['set-cookie'][0]).toContain(
-						`sessionID=${sessionId}; Path=/p/${editorId}; Expires=${sessionCookieExpiryDate}`
+						`sessionID=${sessionId}; Path=/etherpad/; Expires=${sessionCookieExpiryDate}`
 					);
 				});
 			});
@@ -209,10 +203,10 @@ describe('Collaborative Text Editor Controller (API)', () => {
 
 					const editorId = 'editorId';
 					etherpadClientAdapter.getOrCreateEtherpadId.mockResolvedValueOnce(editorId);
-					const otherSessionIds = ['otherSessionId1', 'otherSessionId2'];
-					etherpadClientAdapter.listSessionIdsOfAuthor.mockResolvedValueOnce(otherSessionIds);
 					const sessionId = 'sessionId';
 					etherpadClientAdapter.getOrCreateSessionId.mockResolvedValueOnce(sessionId);
+					const allSessionIds = ['otherSessionId1', 'otherSessionId2', sessionId];
+					etherpadClientAdapter.listSessionIdsOfAuthor.mockResolvedValueOnce(allSessionIds);
 
 					const basePath = 'http://localhost:9001/p';
 					const expectedPath = `${basePath}/${editorId}`;
@@ -228,6 +222,7 @@ describe('Collaborative Text Editor Controller (API)', () => {
 						sessionId,
 						sessionCookieExpiryDate,
 						editorId,
+						allSessionIds,
 					};
 				};
 
@@ -236,10 +231,11 @@ describe('Collaborative Text Editor Controller (API)', () => {
 						loggedInClient,
 						collaborativeTextEditorElement,
 						expectedPath,
-						sessionId,
 						sessionCookieExpiryDate,
-						editorId,
+						allSessionIds,
 					} = await setup();
+
+					const concatenatedSessionIds = encodeURIComponent(allSessionIds.join(','));
 
 					const response = await loggedInClient.get(`content-element/${collaborativeTextEditorElement.id}`);
 
@@ -248,7 +244,7 @@ describe('Collaborative Text Editor Controller (API)', () => {
 					expect(response.body['url']).toEqual(expectedPath);
 
 					expect(response.headers['set-cookie'][0]).toContain(
-						`sessionID=${sessionId}; Path=/p/${editorId}; Expires=${sessionCookieExpiryDate}`
+						`sessionID=${concatenatedSessionIds}; Path=/etherpad/; Expires=${sessionCookieExpiryDate}`
 					);
 				});
 			});
@@ -282,8 +278,8 @@ describe('Collaborative Text Editor Controller (API)', () => {
 					const editorId = 'editorId';
 					etherpadClientAdapter.getOrCreateEtherpadId.mockResolvedValueOnce(editorId);
 					const sessionId = 'sessionId';
-					const otherSessionIds = ['sessionId'];
-					etherpadClientAdapter.listSessionIdsOfAuthor.mockResolvedValueOnce(otherSessionIds);
+					const allSessionIds = ['sessionId'];
+					etherpadClientAdapter.listSessionIdsOfAuthor.mockResolvedValueOnce(allSessionIds);
 					etherpadClientAdapter.getOrCreateSessionId.mockResolvedValueOnce(sessionId);
 
 					const basePath = 'http://localhost:9001/p';
@@ -304,14 +300,8 @@ describe('Collaborative Text Editor Controller (API)', () => {
 				};
 
 				it('should return response and set cookie', async () => {
-					const {
-						loggedInClient,
-						collaborativeTextEditorElement,
-						expectedPath,
-						sessionId,
-						sessionCookieExpiryDate,
-						editorId,
-					} = await setup();
+					const { loggedInClient, collaborativeTextEditorElement, expectedPath, sessionId, sessionCookieExpiryDate } =
+						await setup();
 
 					const response = await loggedInClient.get(`content-element/${collaborativeTextEditorElement.id}`);
 
@@ -320,7 +310,7 @@ describe('Collaborative Text Editor Controller (API)', () => {
 					expect(response.body['url']).toEqual(expectedPath);
 
 					expect(response.headers['set-cookie'][0]).toContain(
-						`sessionID=${sessionId}; Path=/p/${editorId}; Expires=${sessionCookieExpiryDate}`
+						`sessionID=${sessionId}; Path=/etherpad/; Expires=${sessionCookieExpiryDate}`
 					);
 				});
 			});

--- a/apps/server/src/modules/collaborative-text-editor/service/collaborative-text-editor.service.spec.ts
+++ b/apps/server/src/modules/collaborative-text-editor/service/collaborative-text-editor.service.spec.ts
@@ -387,4 +387,105 @@ describe('CollaborativeTextEditorService', () => {
 			});
 		});
 	});
+
+	describe('getSessionIdsOfAuthor', () => {
+		describe('WHEN there is one session for the author', () => {
+			const setup = () => {
+				const userId = 'userId';
+				const authorId = 'authorId';
+				const sessionIds = ['sessionId1', 'sessionId2'];
+
+				etherpadClientAdapter.getOrCreateAuthorId.mockResolvedValueOnce(authorId);
+				etherpadClientAdapter.listSessionIdsOfAuthor.mockResolvedValueOnce(sessionIds);
+
+				return { userId, authorId, sessionIds };
+			};
+
+			it('should return its session id', async () => {
+				const { userId, sessionIds } = setup();
+
+				const result = await service.getSessionIdsOfAuthor(userId);
+
+				expect(result).toEqual(sessionIds);
+			});
+		});
+
+		describe('WHEN there is no session for the author', () => {
+			const setup = () => {
+				const userId = 'userId';
+				const authorId = 'authorId';
+				const sessionIds: string[] = [];
+
+				etherpadClientAdapter.getOrCreateAuthorId.mockResolvedValueOnce(authorId);
+				etherpadClientAdapter.listSessionIdsOfAuthor.mockResolvedValueOnce(sessionIds);
+
+				return { userId, authorId, sessionIds };
+			};
+
+			it('should return an empty array', async () => {
+				const { userId, sessionIds } = setup();
+
+				const result = await service.getSessionIdsOfAuthor(userId);
+
+				expect(result).toEqual(sessionIds);
+			});
+		});
+
+		describe('WHEN there are multiple sessions for the author', () => {
+			const setup = () => {
+				const userId = 'userId';
+				const authorId = 'authorId';
+				const sessionIds = ['sessionId1', 'sessionId2', 'sessionId3'];
+
+				etherpadClientAdapter.getOrCreateAuthorId.mockResolvedValueOnce(authorId);
+				etherpadClientAdapter.listSessionIdsOfAuthor.mockResolvedValueOnce(sessionIds);
+
+				return { userId, authorId, sessionIds };
+			};
+
+			it('should return all session ids', async () => {
+				const { userId, sessionIds } = setup();
+
+				const result = await service.getSessionIdsOfAuthor(userId);
+
+				expect(result).toEqual(sessionIds);
+			});
+		});
+
+		describe('WHEN etherpadClientAdapter.getOrCreateAuthorId throws an error', () => {
+			const setup = () => {
+				const userId = 'userId';
+				const error = new Error('error');
+
+				etherpadClientAdapter.getOrCreateAuthorId.mockRejectedValueOnce(error);
+
+				return { userId, error };
+			};
+
+			it('should throw an error', async () => {
+				const { userId, error } = setup();
+
+				await expect(service.getSessionIdsOfAuthor(userId)).rejects.toThrow(error);
+			});
+		});
+
+		describe('WHEN etherpadClientAdapter.listSessionIdsOfAuthor throws an error', () => {
+			const setup = () => {
+				const userId = 'userId';
+				const authorId = 'authorId';
+				const error = new Error('error');
+
+				etherpadClientAdapter.getOrCreateAuthorId.mockResolvedValueOnce(authorId);
+				etherpadClientAdapter.listSessionIdsOfAuthor.mockRejectedValueOnce(error);
+
+				return { userId, authorId, error };
+			};
+
+			it('should throw an error', async () => {
+				const { userId, error } = setup();
+
+				await expect(service.getSessionIdsOfAuthor(userId)).rejects.toThrow(error);
+			});
+		});
+	});
 });

--- a/apps/server/src/modules/collaborative-text-editor/service/collaborative-text-editor.service.ts
+++ b/apps/server/src/modules/collaborative-text-editor/service/collaborative-text-editor.service.ts
@@ -49,6 +49,13 @@ export class CollaborativeTextEditorService {
 		};
 	}
 
+	public async getSessionIdsOfAuthor(userId: string): Promise<string[]> {
+		const authorId = await this.collaborativeTextEditorAdapter.getOrCreateAuthorId(userId);
+		const sessionIds = await this.collaborativeTextEditorAdapter.listSessionIdsOfAuthor(authorId);
+
+		return sessionIds;
+	}
+
 	public async deleteCollaborativeTextEditorByParentId(parentId: string): Promise<void> {
 		const groupId = await this.collaborativeTextEditorAdapter.getOrCreateGroupId(parentId);
 


### PR DESCRIPTION
# Description
adapt cookie parameters for etherpad sessionID

## Links to Tickets or other pull requests
[BC-12160](https://ticketsystem.dbildungscloud.de/browse/BC-12160)
--> dof-pr einfügen <--

## Changes


## Approval for review

- [ ] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
