### PR TITLE
SVSDEV-112 - switch download-endpoint from get to post

### DIFF
--- a/apps/server/src/modules/files/api/legacy-file-archive.controller.ts
+++ b/apps/server/src/modules/files/api/legacy-file-archive.controller.ts
@@ -1,11 +1,14 @@
 import { JwtAuthentication } from '@infra/auth-guard';
 import {
+	Body,
 	Controller,
 	ForbiddenException,
 	Get,
+	HttpCode,
 	HttpStatus,
 	InternalServerErrorException,
 	NotImplementedException,
+	Post,
 	Query,
 	Req,
 	Res,
@@ -36,9 +39,10 @@ export class LegacyFileArchiveController {
 	@ApiResponse({ status: 500, type: InternalServerErrorException })
 	@ApiResponse({ status: 501, type: NotImplementedException })
 	@ApiHeader({ name: 'Range', required: false })
-	@Get()
+	@Post()
+	@HttpCode(HttpStatus.OK)
 	public async downloadFilesAsArchive(
-		@Query() params: ArchiveFileParams,
+		@Body() params: ArchiveFileParams,
 		@Req() req: Request,
 		@Res({ passthrough: true }) response: Response
 	): Promise<StreamableFile | void> {

--- a/apps/server/src/modules/files/api/test/download-file-as-archive.api.spec.ts
+++ b/apps/server/src/modules/files/api/test/download-file-as-archive.api.spec.ts
@@ -103,7 +103,7 @@ describe('DownloadArchive Controller (API)', () => {
 					archiveName: 'test-archive',
 				};
 
-				const response = await new TestApiClientBuilder(app, baseRouteName).build().get().query(params);
+				const response = await new TestApiClientBuilder(app, baseRouteName).build().post(undefined, params);
 
 				expect(response.status).toEqual(HttpStatus.UNAUTHORIZED);
 			});
@@ -129,7 +129,7 @@ describe('DownloadArchive Controller (API)', () => {
 					archiveName: 'test-archive',
 				};
 
-				const response = await loggedInClient.get().query(params);
+				const response = await loggedInClient.post(undefined, params);
 
 				expect(response.status).toEqual(HttpStatus.BAD_REQUEST);
 				expect(response.body).toEqual(
@@ -160,7 +160,7 @@ describe('DownloadArchive Controller (API)', () => {
 					archiveName: 'test-archive',
 				};
 
-				const response = await loggedInClient.get().query(params);
+				const response = await loggedInClient.post(undefined, params);
 
 				expect(response.status).toEqual(HttpStatus.BAD_REQUEST);
 				expect(response.body).toEqual(
@@ -198,7 +198,7 @@ describe('DownloadArchive Controller (API)', () => {
 					archiveName: 'test-archive',
 				};
 
-				const response = await loggedInClient.get().query(params);
+				const response = await loggedInClient.post(undefined, params);
 
 				expect(response.status).toEqual(HttpStatus.NOT_IMPLEMENTED);
 
@@ -229,7 +229,7 @@ describe('DownloadArchive Controller (API)', () => {
 					archiveName: 'team-archive',
 				};
 
-				const response = await loggedInClient.get().query(params);
+				const response = await loggedInClient.post(undefined, params);
 
 				expect(response.status).toEqual(HttpStatus.FORBIDDEN);
 			});
@@ -257,7 +257,7 @@ describe('DownloadArchive Controller (API)', () => {
 					archiveName: 'course-archive',
 				};
 
-				const response = await loggedInClient.get().query(params);
+				const response = await loggedInClient.post(undefined, params);
 
 				expect(response.status).toEqual(HttpStatus.FORBIDDEN);
 			});
@@ -286,7 +286,7 @@ describe('DownloadArchive Controller (API)', () => {
 					archiveName: 'user-archive',
 				};
 
-				const response = await loggedInClient.get().query(params);
+				const response = await loggedInClient.post(undefined, params);
 
 				expect(response.status).toEqual(HttpStatus.FORBIDDEN);
 			});
@@ -333,7 +333,7 @@ describe('DownloadArchive Controller (API)', () => {
 					archiveName,
 				};
 
-				const response = await loggedInClient.get().query(params);
+				const response = await loggedInClient.post(undefined, params);
 
 				expect(response.status).toEqual(HttpStatus.OK);
 				expect(response.headers['content-type']).toContain('application/zip');
@@ -384,7 +384,7 @@ describe('DownloadArchive Controller (API)', () => {
 					archiveName,
 				};
 
-				const response = await loggedInClient.get().query(params);
+				const response = await loggedInClient.post(undefined, params);
 
 				expect(response.status).toEqual(HttpStatus.OK);
 				expect(response.headers['content-type']).toContain('application/zip');
@@ -435,7 +435,7 @@ describe('DownloadArchive Controller (API)', () => {
 					archiveName,
 				};
 
-				const response = await loggedInClient.get().query(params);
+				const response = await loggedInClient.post(undefined, params);
 
 				expect(response.status).toEqual(HttpStatus.OK);
 				expect(response.headers['content-type']).toContain('application/zip');


### PR DESCRIPTION
# Description
Fix to support very long lists of file-ids and complex structures of folders and sub-folders.

If very many files were selected in the download-filetree, it could happen, that the server returned a http-status 431 (="Request Header Fields Too Large") which resulted in authtication-token not being transmitted completely and authentication failing. 

Changes:
- switched download endpoint from GET to POST
- initially show folders in file-tree as collapsed and add toggle-button to unfold/fold the children
<img width="1033" height="394" alt="Filetree" src="https://github.com/user-attachments/assets/25f34bd0-0db1-4617-b1ac-004492ef9b8d" />

## Links to Tickets or other pull requests
SVSDEV-112
https://github.com/hpi-schul-cloud/schulcloud-client/pull/3901

## Approval for review

- [x] DEV: If api was changed - `generate-client:server` was executed in vue frontend and changes were tested and put in a PR with the same branch name.
- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
